### PR TITLE
[Tests] Add fuzzing for transaction parsing

### DIFF
--- a/tx_fuzz_test.go
+++ b/tx_fuzz_test.go
@@ -38,7 +38,10 @@ func FuzzNewTxFromBytes(f *testing.F) {
 		}
 
 		if len(txBytes) >= 9 {
-			v, _ := bt.NewVarIntFromBytes(txBytes)
+			v, err := bt.NewVarIntFromBytes(txBytes)
+			if err != nil {
+				t.Skipf("malformed varint input: %v", err)
+			}
 			if v > 1_000_000 {
 				t.Skip("varint too big")
 			}


### PR DESCRIPTION
## What Changed
- added a fuzz test that exercises `NewTxFromBytes`
- fuzz test includes safeguards against large allocations and can be enabled with `BT_ENABLE_FUZZ`

## Why It Was Necessary
- improve robustness of transaction parsing when faced with arbitrary input

## Testing Performed
- `go test ./...`
- `make run-fuzz-tests`

## Impact / Risk
- no breaking changes


------
https://chatgpt.com/codex/tasks/task_e_686699131004832192dc07771202a422