### PR TITLE
[Debug] Reduce duplication in debugger tests

### DIFF
--- a/bscript/interpreter/debug/test_helper_test.go
+++ b/bscript/interpreter/debug/test_helper_test.go
@@ -1,0 +1,49 @@
+package debug_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/bsv-blockchain/go-bt/v2/bscript"
+	"github.com/bsv-blockchain/go-bt/v2/bscript/interpreter"
+	"github.com/bsv-blockchain/go-bt/v2/bscript/interpreter/debug"
+	"github.com/stretchr/testify/require"
+)
+
+type stateHistory struct {
+	dstack  [][]string
+	astack  [][]string
+	opcodes []string
+	entries []string
+}
+
+func parseScripts(t *testing.T, lHex, uHex string) (*bscript.Script, *bscript.Script) {
+	t.Helper()
+	l, err := bscript.NewFromHexString(lHex)
+	require.NoError(t, err)
+	u, err := bscript.NewFromHexString(uHex)
+	require.NoError(t, err)
+	return l, u
+}
+
+func runEngine(t *testing.T, lscript, uscript *bscript.Script, dbg debug.DefaultDebugger) error {
+	t.Helper()
+	return interpreter.NewEngine().Execute(
+		interpreter.WithScripts(lscript, uscript),
+		interpreter.WithAfterGenesis(),
+		interpreter.WithDebugger(dbg),
+	)
+}
+
+func snapshot(state *interpreter.State) []string {
+	stack := make([]string, len(state.DataStack))
+	for i, d := range state.DataStack {
+		stack[i] = hex.EncodeToString(d)
+	}
+	return stack
+}
+
+func recordState(h *stateHistory, state *interpreter.State) {
+	h.dstack = append(h.dstack, snapshot(state))
+	h.opcodes = append(h.opcodes, state.Opcode().Name())
+}


### PR DESCRIPTION
## What Changed
- added shared helper functions for debugger tests
- replaced repeated setup and state capture logic with helper usage

## Why It Was Necessary
- debugger tests contained substantial duplication making them harder to maintain
- helper functions centralize common logic for clarity

## Testing Performed
- `golangci-lint run`
- `go vet ./...`
- `go test ./...`

## Impact / Risk
- no breaking API changes
- minimal risk; refactor only affects tests

------
https://chatgpt.com/codex/tasks/task_e_68669d151ee08321ac43d20f7caf2346