### PR TITLE
[tests] refactor tx_test helpers

### DIFF
--- a/tx_test.go
+++ b/tx_test.go
@@ -260,7 +260,7 @@ func TestTxCreateTx(t *testing.T) {
 
 	mustPayToAddress(t, tx, "n2wmGVP89x3DsLNqk3NvctfQy9m9pvt7mk", 1999942)
 
-	wif := decodeWIF(t, "KznvCNc6Yf4iztSThoMH6oHWzH9EgjfodKxmeuUGPq5DEX5maspS")
+	wif := decodeWIF(t, testWIFKey)
 	fillAllInputs(t, tx, wif)
 }
 


### PR DESCRIPTION
## What Changed
- add helper functions for decoding WIFs and filling inputs
- refactor `tx_test.go` to use these helpers

## Why It Was Necessary
- reduce duplicated code across tests reported by SonarCube

## Testing Performed
- `golangci-lint run`
- `go test ./...`

## Impact / Risk
- no functional changes to the library
- tests remain the same but easier to maintain

------
https://chatgpt.com/codex/tasks/task_e_6866a351b0348321800ad77061ecd61e