### PR TITLE
Remove go-bk as a dependency

### DIFF
--- a/bscript/address.go
+++ b/bscript/address.go
@@ -5,9 +5,9 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	"github.com/libsv/go-bk/base58"
-	"github.com/libsv/go-bk/bec"
-	"github.com/libsv/go-bk/crypto"
+	base58 "github.com/bsv-blockchain/go-sdk/compat/base58"
+	bec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+	crypto "github.com/bsv-blockchain/go-sdk/primitives/hash"
 )
 
 const (
@@ -39,7 +39,10 @@ func NewAddressFromString(addr string) (*Address, error) {
 }
 
 func addressToPubKeyHashStr(address string) (string, error) {
-	decoded := base58.Decode(address)
+	decoded, err := base58.Decode(address)
+	if err != nil {
+		return "", err
+	}
 
 	if len(decoded) != 25 {
 		return "", fmt.Errorf("%w for '%s'", ErrInvalidAddressLength, address)
@@ -97,7 +100,7 @@ func NewAddressFromPublicKeyHash(hash []byte, mainnet bool) (*Address, error) {
 // If mainnet parameter is true it will return a mainnet address (starting with a 1).
 // Otherwise, (mainnet is false) it will return a testnet address (starting with an m or n).
 func NewAddressFromPublicKey(pubKey *bec.PublicKey, mainnet bool) (*Address, error) {
-	hash := crypto.Hash160(pubKey.SerialiseCompressed())
+	hash := crypto.Hash160(pubKey.Compressed())
 
 	// regtest := 111
 	// mainnet: 0

--- a/bscript/address_test.go
+++ b/bscript/address_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/bsv-blockchain/go-bt/v2/bscript"
-	"github.com/libsv/go-bk/bec"
+	bec "github.com/bsv-blockchain/go-sdk/primitives/ec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -90,7 +90,7 @@ func TestNewAddressFromPublicKey(t *testing.T) {
 	require.NoError(t, err)
 
 	var pubKey *bec.PublicKey
-	pubKey, err = bec.ParsePubKey(pubKeyBytes, bec.S256())
+	pubKey, err = bec.ParsePubKey(pubKeyBytes)
 	require.NoError(t, err)
 	assert.NotNil(t, pubKey)
 

--- a/bscript/address_validation.go
+++ b/bscript/address_validation.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/libsv/go-bk/crypto"
+	crypto "github.com/bsv-blockchain/go-sdk/primitives/hash"
 )
 
 type a25 [25]byte

--- a/bscript/bip_276.go
+++ b/bscript/bip_276.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"strconv"
 
-	"github.com/libsv/go-bk/crypto"
+	crypto "github.com/bsv-blockchain/go-sdk/primitives/hash"
 )
 
 // BIP276 proposes a scheme for encoding typed bitcoin related data in a user-friendly way

--- a/bscript/interpreter/thread.go
+++ b/bscript/interpreter/thread.go
@@ -8,7 +8,7 @@ import (
 	"github.com/bsv-blockchain/go-bt/v2/bscript/interpreter/errs"
 	"github.com/bsv-blockchain/go-bt/v2/bscript/interpreter/scriptflag"
 	"github.com/bsv-blockchain/go-bt/v2/sighash"
-	"github.com/libsv/go-bk/bec"
+	bec "github.com/bsv-blockchain/go-sdk/primitives/ec"
 )
 
 // halfOrder is used to tame ECDSA malleability (see BIP0062).

--- a/bscript/script.go
+++ b/bscript/script.go
@@ -9,9 +9,9 @@ import (
 	"math/bits"
 	"strings"
 
-	"github.com/libsv/go-bk/bec"
-	"github.com/libsv/go-bk/bip32"
-	"github.com/libsv/go-bk/crypto"
+	bip32 "github.com/bsv-blockchain/go-sdk/compat/bip32"
+	bec "github.com/bsv-blockchain/go-sdk/primitives/ec"
+	crypto "github.com/bsv-blockchain/go-sdk/primitives/hash"
 )
 
 // ScriptKey types.
@@ -64,7 +64,7 @@ func NewFromASM(str string) (*Script, error) {
 // NewP2PKHFromPubKeyEC takes a public key hex string (in
 // compressed format) and creates a P2PKH script from it.
 func NewP2PKHFromPubKeyEC(pubKey *bec.PublicKey) (*Script, error) {
-	return NewP2PKHFromPubKeyBytes(pubKey.SerialiseCompressed())
+	return NewP2PKHFromPubKeyBytes(pubKey.Compressed())
 }
 
 // NewP2PKHFromPubKeyStr takes a public key hex string (in

--- a/bscript/script_test.go
+++ b/bscript/script_test.go
@@ -9,9 +9,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/libsv/go-bk/bec"
-	"github.com/libsv/go-bk/bip32"
-	"github.com/libsv/go-bk/chaincfg"
+	transaction "github.com/bsv-blockchain/go-sdk/transaction/chaincfg"
+
+	bip32 "github.com/bsv-blockchain/go-sdk/compat/bip32"
+	bec "github.com/bsv-blockchain/go-sdk/primitives/ec"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -38,7 +39,7 @@ func TestNewP2PKHFromPubKey(t *testing.T) {
 
 	pk, _ := hex.DecodeString("023717efaec6761e457f55c8417815505b695209d0bbfed8c3265be425b373c2d6")
 
-	pubkey, err := bec.ParsePubKey(pk, bec.S256())
+	pubkey, err := bec.ParsePubKey(pk)
 	require.NoError(t, err)
 
 	scriptP2PKH, err := bscript.NewP2PKHFromPubKeyEC(pubkey)
@@ -58,7 +59,7 @@ func TestNewP2PKHFromBip32ExtKey(t *testing.T) {
 		_, err := rand.Read(b[:])
 		require.NoError(t, err)
 
-		key, err := bip32.NewMaster(b[:], &chaincfg.TestNet)
+		key, err := bip32.NewMaster(b[:], &transaction.TestNet)
 		require.NoError(t, err)
 
 		script, derivationPath, err := bscript.NewP2PKHFromBip32ExtKey(key)

--- a/bscript/unlocking_script_test.go
+++ b/bscript/unlocking_script_test.go
@@ -3,7 +3,8 @@ package bscript
 import (
 	"testing"
 
-	"github.com/libsv/go-bk/wif"
+	primitives "github.com/bsv-blockchain/go-sdk/primitives/ec"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -12,12 +13,12 @@ func TestNewP2PKHUnlockingScript(t *testing.T) {
 
 	t.Run("unlock script with valid pubkey", func(t *testing.T) {
 
-		decodedWif, err := wif.DecodeWIF("KznvCNc6Yf4iztSThoMH6oHWzH9EgjfodKxmeuUGPq5DEX5maspS")
+		decodedWif, err := primitives.PrivateKeyFromWif("KznvCNc6Yf4iztSThoMH6oHWzH9EgjfodKxmeuUGPq5DEX5maspS")
 		require.NoError(t, err)
 		assert.NotNil(t, decodedWif)
 
 		var script *Script
-		script, err = NewP2PKHUnlockingScript(decodedWif.SerialisePubKey(), []byte("some-signature"), 0)
+		script, err = NewP2PKHUnlockingScript(decodedWif.PubKey().Compressed(), []byte("some-signature"), 0)
 		require.NoError(t, err)
 		assert.NotNil(t, script)
 		assert.Equal(t, "0f736f6d652d7369676e6174757265002102798913bc057b344de675dac34faafe3dc2f312c758cd9068209f810877306d66", script.String())

--- a/byte_manipulation_test.go
+++ b/byte_manipulation_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/bsv-blockchain/go-bt/v2"
-	"github.com/libsv/go-bk/crypto"
+	crypto "github.com/bsv-blockchain/go-sdk/primitives/hash"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/examples/create_ordinal_bid/create_ordinal_bid.go
+++ b/examples/create_ordinal_bid/create_ordinal_bid.go
@@ -6,19 +6,20 @@ import (
 	"encoding/hex"
 	"log"
 
+	primitives "github.com/bsv-blockchain/go-sdk/primitives/ec"
+
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/bscript"
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/bsv-blockchain/go-bt/v2/ord"
 	"github.com/bsv-blockchain/go-bt/v2/unlocker"
-	"github.com/libsv/go-bk/wif"
 )
 
 func main() {
-	fundingWif, _ := wif.DecodeWIF("L5W2nyKUCsDStVUBwZj2Q3Ph5vcae4bgdzprZDYqDpvZA8AFguFH") // 19NfKd8aTwvb5ngfP29RxgfQzZt8KAYtQo
-	fundingAddr, _ := bscript.NewAddressFromPublicKeyString(hex.EncodeToString(fundingWif.SerialisePubKey()), true)
+	fundingPk, _ := primitives.PrivateKeyFromWif("L5W2nyKUCsDStVUBwZj2Q3Ph5vcae4bgdzprZDYqDpvZA8AFguFH") // 19NfKd8aTwvb5ngfP29RxgfQzZt8KAYtQo
+	fundingAddr, _ := bscript.NewAddressFromPublicKeyString(hex.EncodeToString(fundingPk.PubKey().Compressed()), true)
 	fundingScript, _ := bscript.NewP2PKHFromAddress(fundingAddr.AddressString)
-	fundingUnlockerGetter := unlocker.Getter{PrivateKey: fundingWif.PrivKey}
+	fundingUnlockerGetter := unlocker.Getter{PrivateKey: fundingPk}
 	fundingUnlocker, _ := fundingUnlockerGetter.Unlocker(context.Background(), fundingScript)
 
 	bidAmount := 100000000

--- a/examples/create_tx/create_tx.go
+++ b/examples/create_tx/create_tx.go
@@ -5,9 +5,10 @@ import (
 	"context"
 	"log"
 
+	primitives "github.com/bsv-blockchain/go-sdk/primitives/ec"
+
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/unlocker"
-	"github.com/libsv/go-bk/wif"
 )
 
 func main() {
@@ -22,9 +23,9 @@ func main() {
 
 	_ = tx.PayToAddress("1NRoySJ9Lvby6DuE2UQYnyT67AASwNZxGb", 1000)
 
-	decodedWif, _ := wif.DecodeWIF("KznvCNc6Yf4iztSThoMH6oHWzH9EgjfodKxmeuUGPq5DEX5maspS")
+	pk, _ := primitives.PrivateKeyFromWif("KznvCNc6Yf4iztSThoMH6oHWzH9EgjfodKxmeuUGPq5DEX5maspS")
 
-	if err := tx.FillAllInputs(context.Background(), &unlocker.Getter{PrivateKey: decodedWif.PrivKey}); err != nil {
+	if err := tx.FillAllInputs(context.Background(), &unlocker.Getter{PrivateKey: pk}); err != nil {
 		log.Fatal(err.Error())
 	}
 	log.Printf("tx: %s\n", tx)

--- a/examples/create_tx_with_inscription/create_tx_with_inscription.go
+++ b/examples/create_tx_with_inscription/create_tx_with_inscription.go
@@ -8,17 +8,18 @@ import (
 	"mime"
 	"os"
 
+	primitives "github.com/bsv-blockchain/go-sdk/primitives/ec"
+
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/bscript"
 	"github.com/bsv-blockchain/go-bt/v2/unlocker"
-	"github.com/libsv/go-bk/wif"
 )
 
 func main() {
-	decodedWif, _ := wif.DecodeWIF("KznpA63DPFrmHecASyL6sFmcRgrNT9oM8Ebso8mwq1dfJF3ZgZ3V")
+	pk, _ := primitives.PrivateKeyFromWif("KznpA63DPFrmHecASyL6sFmcRgrNT9oM8Ebso8mwq1dfJF3ZgZ3V")
 
 	// get public key bytes and address
-	pubkey := decodedWif.SerialisePubKey()
+	pubkey := pk.PubKey().Compressed()
 	addr, _ := bscript.NewAddressFromPublicKeyString(hex.EncodeToString(pubkey), true)
 	s, _ := bscript.NewP2PKHFromAddress(addr.AddressString)
 	log.Println(addr.AddressString)
@@ -56,7 +57,7 @@ func main() {
 		log.Fatal(err.Error())
 	}
 
-	err = tx.FillAllInputs(context.Background(), &unlocker.Getter{PrivateKey: decodedWif.PrivKey})
+	err = tx.FillAllInputs(context.Background(), &unlocker.Getter{PrivateKey: pk})
 	if err != nil {
 		log.Fatal(err.Error())
 	}

--- a/examples/create_tx_with_opreturn/create_tx_with_opreturn.go
+++ b/examples/create_tx_with_opreturn/create_tx_with_opreturn.go
@@ -5,9 +5,10 @@ import (
 	"context"
 	"log"
 
+	primitives "github.com/bsv-blockchain/go-sdk/primitives/ec"
+
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/unlocker"
-	"github.com/libsv/go-bk/wif"
 )
 
 func main() {
@@ -24,9 +25,9 @@ func main() {
 
 	_ = tx.AddOpReturnOutput([]byte("You are using go-bt!"))
 
-	decodedWif, _ := wif.DecodeWIF("L3VJH2hcRGYYG6YrbWGmsxQC1zyYixA82YjgEyrEUWDs4ALgk8Vu")
+	pk, _ := primitives.PrivateKeyFromWif("L3VJH2hcRGYYG6YrbWGmsxQC1zyYixA82YjgEyrEUWDs4ALgk8Vu")
 
-	err := tx.FillAllInputs(context.Background(), &unlocker.Getter{PrivateKey: decodedWif.PrivKey})
+	err := tx.FillAllInputs(context.Background(), &unlocker.Getter{PrivateKey: pk})
 	if err != nil {
 		log.Fatal(err.Error())
 	}

--- a/examples/unlocker_getter/account.go
+++ b/examples/unlocker_getter/account.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 
+	transaction "github.com/bsv-blockchain/go-sdk/transaction/chaincfg"
+
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/bscript"
 	"github.com/bsv-blockchain/go-bt/v2/unlocker"
-	"github.com/libsv/go-bk/bip32"
-	"github.com/libsv/go-bk/chaincfg"
+	bip32 "github.com/bsv-blockchain/go-sdk/compat/bip32"
 )
 
 // account for creating destination scripts and stores these scripts with their derivations.
@@ -27,7 +28,7 @@ func newAccount() *account {
 	if err != nil {
 		panic(err)
 	}
-	privKey, err := bip32.NewMaster(seed, &chaincfg.MainNet)
+	privKey, err := bip32.NewMaster(seed, &transaction.MainNet)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/unlocker_getter/main.go
+++ b/examples/unlocker_getter/main.go
@@ -4,10 +4,11 @@ package main
 import (
 	"context"
 
+	primitives "github.com/bsv-blockchain/go-sdk/primitives/ec"
+
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/bscript"
 	"github.com/bsv-blockchain/go-bt/v2/unlocker"
-	"github.com/libsv/go-bk/wif"
 )
 
 // This example gives a simple in-memory-based example of how to implement and use a `bt.UnlockerGetter`
@@ -45,9 +46,9 @@ func main() {
 		panic(err)
 	}
 
-	// decoded Wif just for signing the base tx. It isn't relevant to myAccount or merchantAccount,
+	// pk used just for signing the base tx. It isn't relevant to myAccount or merchantAccount,
 	// and can be ignored.
-	decodedWif, err := wif.DecodeWIF("KznvCNc6Yf4iztSThoMH6oHWzH9EgjfodKxmeuUGPq5DEX5maspS")
+	pk, err := primitives.PrivateKeyFromWif("KznvCNc6Yf4iztSThoMH6oHWzH9EgjfodKxmeuUGPq5DEX5maspS")
 	if err != nil {
 		panic(err)
 	}
@@ -62,7 +63,7 @@ func main() {
 		}
 	}
 
-	changeScript, err := bscript.NewP2PKHFromPubKeyEC(decodedWif.PrivKey.PubKey())
+	changeScript, err := bscript.NewP2PKHFromPubKeyEC(pk.PubKey())
 	if err != nil {
 		panic(err)
 	}
@@ -73,7 +74,7 @@ func main() {
 
 	if err = baseTx.FillInput(
 		context.Background(),
-		&unlocker.Simple{PrivateKey: decodedWif.PrivKey},
+		&unlocker.Simple{PrivateKey: pk},
 		bt.UnlockerParams{},
 	); err != nil {
 		panic(err)

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,11 @@
 module github.com/bsv-blockchain/go-bt/v2
 
-go 1.24.0
+go 1.24.3
+
+toolchain go1.24.4
 
 require (
-	github.com/libsv/go-bk v0.1.6
+	github.com/bsv-blockchain/go-sdk v1.2.4
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/crypto v0.39.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/bsv-blockchain/go-sdk v1.2.4 h1:Vl+u/PoBl3+wtQF7CoRTLhBCqIs+MqHgB/xj76+rKHI=
+github.com/bsv-blockchain/go-sdk v1.2.4/go.mod h1:Sb665obrV1FUpM6mRb7fOYNgoOFdQw2+9hag6ApuNQk=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -10,8 +12,6 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
-github.com/libsv/go-bk v0.1.6 h1:c9CiT5+64HRDbzxPl1v/oiFmbvWZTuUYqywCf+MBs/c=
-github.com/libsv/go-bk v0.1.6/go.mod h1:khJboDoH18FPUaZlzRFKzlVN84d4YfdmlDtdX4LAjQA=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/inscriptions_test.go
+++ b/inscriptions_test.go
@@ -8,8 +8,9 @@ import (
 	"os"
 	"testing"
 
+	primitives "github.com/bsv-blockchain/go-sdk/primitives/ec"
+
 	"github.com/bsv-blockchain/go-bt/v2/bscript"
-	"github.com/libsv/go-bk/wif"
 	"github.com/stretchr/testify/require"
 )
 
@@ -77,10 +78,10 @@ func TestInscribe(t *testing.T) {
 }
 
 func TestMultipleInscriptionsIn1Tx(t *testing.T) {
-	decodedWif, _ := wif.DecodeWIF("KznpA63DPFrmHecASyL6sFmcRgrNT9oM8Ebso8mwq1dfJF3ZgZ3V")
+	decodedPk, _ := primitives.PrivateKeyFromWif("KznpA63DPFrmHecASyL6sFmcRgrNT9oM8Ebso8mwq1dfJF3ZgZ3V")
 
 	// get public key bytes and address
-	pubkey := decodedWif.SerialisePubKey()
+	pubkey := decodedPk.PubKey().Compressed()
 	addr, _ := bscript.NewAddressFromPublicKeyString(hex.EncodeToString(pubkey), true)
 	s, _ := bscript.NewP2PKHFromAddress(addr.AddressString)
 
@@ -134,10 +135,10 @@ func TestMultipleInscriptionsIn1Tx(t *testing.T) {
 }
 
 func TestInscribeFromFile(t *testing.T) {
-	decodedWif, _ := wif.DecodeWIF("KznpA63DPFrmHecASyL6sFmcRgrNT9oM8Ebso8mwq1dfJF3ZgZ3V")
+	decodedPk, _ := primitives.PrivateKeyFromWif("KznpA63DPFrmHecASyL6sFmcRgrNT9oM8Ebso8mwq1dfJF3ZgZ3V")
 
 	// get public key bytes and address
-	pubkey := decodedWif.SerialisePubKey()
+	pubkey := decodedPk.PubKey().Compressed()
 	addr, _ := bscript.NewAddressFromPublicKeyString(hex.EncodeToString(pubkey), true)
 	s, _ := bscript.NewP2PKHFromAddress(addr.AddressString)
 

--- a/ord/2dummies_test.go
+++ b/ord/2dummies_test.go
@@ -5,21 +5,22 @@ import (
 	"encoding/hex"
 	"testing"
 
+	primitives "github.com/bsv-blockchain/go-sdk/primitives/ec"
+
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/bscript"
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/bsv-blockchain/go-bt/v2/ord"
 	"github.com/bsv-blockchain/go-bt/v2/unlocker"
-	"github.com/libsv/go-bk/wif"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestBidToBuyPSBT2DNoErrors(t *testing.T) {
-	fundingWif, _ := wif.DecodeWIF("L5W2nyKUCsDStVUBwZj2Q3Ph5vcae4bgdzprZDYqDpvZA8AFguFH") // 19NfKd8aTwvb5ngfP29RxgfQzZt8KAYtQo
-	fundingAddr, _ := bscript.NewAddressFromPublicKeyString(hex.EncodeToString(fundingWif.SerialisePubKey()), true)
+	fundingPk, _ := primitives.PrivateKeyFromWif("L5W2nyKUCsDStVUBwZj2Q3Ph5vcae4bgdzprZDYqDpvZA8AFguFH") // 19NfKd8aTwvb5ngfP29RxgfQzZt8KAYtQo
+	fundingAddr, _ := bscript.NewAddressFromPublicKeyString(hex.EncodeToString(fundingPk.PubKey().Compressed()), true)
 	fundingScript, _ := bscript.NewP2PKHFromAddress(fundingAddr.AddressString)
-	fundingUnlockerGetter := unlocker.Getter{PrivateKey: fundingWif.PrivKey}
+	fundingUnlockerGetter := unlocker.Getter{PrivateKey: fundingPk}
 	fundingUnlocker, _ := fundingUnlockerGetter.Unlocker(context.Background(), fundingScript)
 
 	bidAmount := 250
@@ -57,10 +58,10 @@ func TestBidToBuyPSBT2DNoErrors(t *testing.T) {
 		},
 	}
 
-	ordWif, _ := wif.DecodeWIF("KwQq67d4Jds3wxs3kQHB8PPwaoaBQfNKkzAacZeMesb7zXojVYpj") // 1HebepswCi6huw1KJ7LvkrgemAV63TyVUs
-	ordPrefixAddr, _ := bscript.NewAddressFromPublicKeyString(hex.EncodeToString(ordWif.SerialisePubKey()), true)
+	ordPk, _ := primitives.PrivateKeyFromWif("KwQq67d4Jds3wxs3kQHB8PPwaoaBQfNKkzAacZeMesb7zXojVYpj") // 1HebepswCi6huw1KJ7LvkrgemAV63TyVUs
+	ordPrefixAddr, _ := bscript.NewAddressFromPublicKeyString(hex.EncodeToString(ordPk.PubKey().Compressed()), true)
 	ordPrefixScript, _ := bscript.NewP2PKHFromAddress(ordPrefixAddr.AddressString)
-	ordUnlockerGetter := unlocker.Getter{PrivateKey: ordWif.PrivKey}
+	ordUnlockerGetter := unlocker.Getter{PrivateKey: ordPk}
 	ordUnlocker, _ := ordUnlockerGetter.Unlocker(context.Background(), ordPrefixScript)
 
 	ordUTXO := &bt.UTXO{

--- a/ord/bid_test.go
+++ b/ord/bid_test.go
@@ -6,21 +6,22 @@ import (
 	"log"
 	"testing"
 
+	primitives "github.com/bsv-blockchain/go-sdk/primitives/ec"
+
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/bscript"
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/bsv-blockchain/go-bt/v2/ord"
 	"github.com/bsv-blockchain/go-bt/v2/unlocker"
-	"github.com/libsv/go-bk/wif"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestBidToBuyPSBTNoErrors(t *testing.T) {
-	fundingWif, _ := wif.DecodeWIF("L42PyNwEKE4XRaa8PzPh7JZurSAWJmx49nbVfaXYuiQg3RCubwn7") // 1JijRHzVfub38S2hizxkxEcVKQwuCTZmxJ
-	fundingAddr, _ := bscript.NewAddressFromPublicKeyString(hex.EncodeToString(fundingWif.SerialisePubKey()), true)
+	fundingPk, _ := primitives.PrivateKeyFromWif("L42PyNwEKE4XRaa8PzPh7JZurSAWJmx49nbVfaXYuiQg3RCubwn7") // 1JijRHzVfub38S2hizxkxEcVKQwuCTZmxJ
+	fundingAddr, _ := bscript.NewAddressFromPublicKeyString(hex.EncodeToString(fundingPk.PubKey().Compressed()), true)
 	fundingScript, _ := bscript.NewP2PKHFromAddress(fundingAddr.AddressString)
-	fundingUnlockerGetter := unlocker.Getter{PrivateKey: fundingWif.PrivKey}
+	fundingUnlockerGetter := unlocker.Getter{PrivateKey: fundingPk}
 	fundingUnlocker, _ := fundingUnlockerGetter.Unlocker(context.Background(), fundingScript)
 
 	bidAmount := 500
@@ -97,10 +98,10 @@ func TestBidToBuyPSBTNoErrors(t *testing.T) {
 	log.Println(pstx.String())
 
 	t.Run("no errors when accepting bid", func(t *testing.T) {
-		ordWif, _ := wif.DecodeWIF("KwQq67d4Jds3wxs3kQHB8PPwaoaBQfNKkzAacZeMesb7zXojVYpj") // 1HebepswCi6huw1KJ7LvkrgemAV63TyVUs
-		ordPrefixAddr, _ := bscript.NewAddressFromPublicKeyString(hex.EncodeToString(ordWif.SerialisePubKey()), true)
+		ordPk, _ := primitives.PrivateKeyFromWif("KwQq67d4Jds3wxs3kQHB8PPwaoaBQfNKkzAacZeMesb7zXojVYpj") // 1HebepswCi6huw1KJ7LvkrgemAV63TyVUs
+		ordPrefixAddr, _ := bscript.NewAddressFromPublicKeyString(hex.EncodeToString(ordPk.PubKey().Compressed()), true)
 		ordPrefixScript, _ := bscript.NewP2PKHFromAddress(ordPrefixAddr.AddressString)
-		ordUnlockerGetter := unlocker.Getter{PrivateKey: ordWif.PrivKey}
+		ordUnlockerGetter := unlocker.Getter{PrivateKey: ordPk}
 		ordUnlocker, _ := ordUnlockerGetter.Unlocker(context.Background(), ordPrefixScript)
 
 		tx, err := ord.AcceptBidToBuy1SatOrdinal(context.Background(), &ord.ValidateBidArgs{

--- a/ord/list_test.go
+++ b/ord/list_test.go
@@ -5,22 +5,23 @@ import (
 	"encoding/hex"
 	"testing"
 
+	primitives "github.com/bsv-blockchain/go-sdk/primitives/ec"
+
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/bscript"
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/bsv-blockchain/go-bt/v2/ord"
 	"github.com/bsv-blockchain/go-bt/v2/unlocker"
-	"github.com/libsv/go-bk/wif"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestOfferToSellPSBTNoErrors(t *testing.T) {
-	ordWif, _ := wif.DecodeWIF("L42PyNwEKE4XRaa8PzPh7JZurSAWJmx49nbVfaXYuiQg3RCubwn7") // 1JijRHzVfub38S2hizxkxEcVKQwuCTZmxJ
-	ordPrefixAddr, _ := bscript.NewAddressFromPublicKeyString(hex.EncodeToString(ordWif.SerialisePubKey()), true)
+	ordPk, _ := primitives.PrivateKeyFromWif("L42PyNwEKE4XRaa8PzPh7JZurSAWJmx49nbVfaXYuiQg3RCubwn7") // 1JijRHzVfub38S2hizxkxEcVKQwuCTZmxJ
+	ordPrefixAddr, _ := bscript.NewAddressFromPublicKeyString(hex.EncodeToString(ordPk.PubKey().Compressed()), true)
 	ordPrefixScript, _ := bscript.NewP2PKHFromAddress(ordPrefixAddr.AddressString)
 
-	ordUnlockerGetter := unlocker.Getter{PrivateKey: ordWif.PrivKey}
+	ordUnlockerGetter := unlocker.Getter{PrivateKey: ordPk}
 	ordUnlocker, _ := ordUnlockerGetter.Unlocker(context.Background(), ordPrefixScript)
 
 	ordUTXO := &bt.UTXO{

--- a/signature_hash.go
+++ b/signature_hash.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/bsv-blockchain/go-bt/v2/bscript"
 	"github.com/bsv-blockchain/go-bt/v2/sighash"
-	"github.com/libsv/go-bk/crypto"
+	crypto "github.com/bsv-blockchain/go-sdk/primitives/hash"
 )
 
 // defaultHex is used to fix a bug in the original client (see if statement in the CalcInputSignatureHash func)

--- a/test_helper_test.go
+++ b/test_helper_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"testing"
 
+	primitives "github.com/bsv-blockchain/go-sdk/primitives/ec"
+
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/unlocker"
-	wifpkg "github.com/libsv/go-bk/wif"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,9 +24,9 @@ func newTxWithInput(t *testing.T, txID string, idx uint32, script string, satosh
 // signAllInputs signs all transaction inputs using the provided WIF key.
 func signAllInputs(t *testing.T, tx *bt.Tx, wifStr string) {
 	t.Helper()
-	wif, err := wifpkg.DecodeWIF(wifStr)
+	pk, err := primitives.PrivateKeyFromWif(wifStr)
 	require.NoError(t, err)
-	require.NoError(t, tx.FillAllInputs(context.Background(), &unlocker.Getter{PrivateKey: wif.PrivKey}))
+	require.NoError(t, tx.FillAllInputs(context.Background(), &unlocker.Getter{PrivateKey: pk}))
 }
 
 const testWIF = "L3MhnEn1pLWcggeYLk9jdkvA2wUK1iWwwrGkBbgQRqv6HPCdRxuw"

--- a/tx.go
+++ b/tx.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/bsv-blockchain/go-bt/v2/bscript"
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
-	"github.com/libsv/go-bk/crypto"
+	crypto "github.com/bsv-blockchain/go-sdk/primitives/hash"
 )
 
 /*

--- a/tx_input.go
+++ b/tx_input.go
@@ -6,7 +6,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"github.com/libsv/go-bk/crypto"
+	crypto "github.com/bsv-blockchain/go-sdk/primitives/hash"
 	"github.com/pkg/errors"
 
 	"github.com/bsv-blockchain/go-bt/v2/bscript"

--- a/tx_input_test.go
+++ b/tx_input_test.go
@@ -7,12 +7,13 @@ import (
 	"math"
 	"testing"
 
+	primitives "github.com/bsv-blockchain/go-sdk/primitives/ec"
+
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/bscript"
 	"github.com/bsv-blockchain/go-bt/v2/chainhash"
 	"github.com/bsv-blockchain/go-bt/v2/sighash"
 	"github.com/bsv-blockchain/go-bt/v2/unlocker"
-	wifpkg "github.com/libsv/go-bk/wif"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -622,22 +623,20 @@ func TestTx_FillInput(t *testing.T) {
 			inputIdx: 0,
 			shf:      sighash.AllForkID,
 			unlocker: func() bt.Unlocker {
-				var wif *wifpkg.WIF
-				wif, err := wifpkg.DecodeWIF("L3MhnEn1pLWcggeYLk9jdkvA2wUK1iWwwrGkBbgQRqv6HPCdRxuw")
+				pk, err := primitives.PrivateKeyFromWif("L3MhnEn1pLWcggeYLk9jdkvA2wUK1iWwwrGkBbgQRqv6HPCdRxuw")
 				require.NoError(t, err)
 
-				return &unlocker.Simple{PrivateKey: wif.PrivKey}
+				return &unlocker.Simple{PrivateKey: pk}
 			}(),
 			expHex: "01000000010b94a1ef0fb352aa2adc54207ce47ba55d5a1c1609afda58fe9520e472299107000000006a473044022049ee0c0f26c00e6a6b3af5990fc8296c66eab3e3e42ab075069b89b1be6fefec02206079e49dd8c9e1117ef06fbe99714d822620b1f0f5d19f32a1128f5d29b7c3c4412102c8803fdd437d902f08e3c2344cb33065c99d7c99982018ff9f7219c3dd352ff0ffffffff01a0083d00000000001976a914af2590a45ae401651fdbdf59a76ad43d1862534088ac00000000",
 		},
 		"sighash all is used as default": {
 			inputIdx: 0,
 			unlocker: func() bt.Unlocker {
-				var wif *wifpkg.WIF
-				wif, err := wifpkg.DecodeWIF("L3MhnEn1pLWcggeYLk9jdkvA2wUK1iWwwrGkBbgQRqv6HPCdRxuw")
+				pk, err := primitives.PrivateKeyFromWif("L3MhnEn1pLWcggeYLk9jdkvA2wUK1iWwwrGkBbgQRqv6HPCdRxuw")
 				require.NoError(t, err)
 
-				return &unlocker.Simple{PrivateKey: wif.PrivKey}
+				return &unlocker.Simple{PrivateKey: pk}
 			}(),
 			expHex: "01000000010b94a1ef0fb352aa2adc54207ce47ba55d5a1c1609afda58fe9520e472299107000000006a473044022049ee0c0f26c00e6a6b3af5990fc8296c66eab3e3e42ab075069b89b1be6fefec02206079e49dd8c9e1117ef06fbe99714d822620b1f0f5d19f32a1128f5d29b7c3c4412102c8803fdd437d902f08e3c2344cb33065c99d7c99982018ff9f7219c3dd352ff0ffffffff01a0083d00000000001976a914af2590a45ae401651fdbdf59a76ad43d1862534088ac00000000",
 		},
@@ -691,14 +690,13 @@ func TestTx_FillAllInputs(t *testing.T) {
 		err = tx.ChangeToAddress("mwV3YgnowbJJB3LcyCuqiKpdivvNNFiK7M", FQPoint5SatPerByte)
 		require.NoError(t, err)
 
-		var wif *wifpkg.WIF
-		wif, err = wifpkg.DecodeWIF("L3MhnEn1pLWcggeYLk9jdkvA2wUK1iWwwrGkBbgQRqv6HPCdRxuw")
+		pk, err := primitives.PrivateKeyFromWif("L3MhnEn1pLWcggeYLk9jdkvA2wUK1iWwwrGkBbgQRqv6HPCdRxuw")
 		require.NoError(t, err)
-		assert.NotNil(t, wif)
+		assert.NotNil(t, pk)
 
 		rawTxBefore := tx.String()
 
-		require.NoError(t, tx.FillAllInputs(context.Background(), &unlocker.Getter{PrivateKey: wif.PrivKey}))
+		require.NoError(t, tx.FillAllInputs(context.Background(), &unlocker.Getter{PrivateKey: pk}))
 
 		assert.NotEqual(t, rawTxBefore, tx.String())
 	})

--- a/tx_json_node_test.go
+++ b/tx_json_node_test.go
@@ -5,10 +5,11 @@ import (
 	"encoding/json"
 	"testing"
 
+	primitives "github.com/bsv-blockchain/go-sdk/primitives/ec"
+
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/bscript"
 	"github.com/bsv-blockchain/go-bt/v2/unlocker"
-	"github.com/libsv/go-bk/wif"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -28,11 +29,11 @@ func TestTxJSON_Node_JSON(t *testing.T) {
 					2000000,
 				))
 				require.NoError(t, tx.PayToAddress("n2wmGVP89x3DsLNqk3NvctfQy9m9pvt7mk", 1000))
-				w, err := wif.DecodeWIF("KznvCNc6Yf4iztSThoMH6oHWzH9EgjfodKxmeuUGPq5DEX5maspS")
+				pk, err := primitives.PrivateKeyFromWif("KznvCNc6Yf4iztSThoMH6oHWzH9EgjfodKxmeuUGPq5DEX5maspS")
 				require.NoError(t, err)
-				assert.NotNil(t, w)
+				assert.NotNil(t, pk)
 
-				err = tx.FillAllInputs(context.Background(), &unlocker.Getter{PrivateKey: w.PrivKey})
+				err = tx.FillAllInputs(context.Background(), &unlocker.Getter{PrivateKey: pk})
 				require.NoError(t, err)
 				return tx
 			}(),
@@ -46,15 +47,15 @@ func TestTxJSON_Node_JSON(t *testing.T) {
 					2000000,
 				))
 				require.NoError(t, tx.PayToAddress("n2wmGVP89x3DsLNqk3NvctfQy9m9pvt7mk", 1000))
-				w, err := wif.DecodeWIF("KznvCNc6Yf4iztSThoMH6oHWzH9EgjfodKxmeuUGPq5DEX5maspS")
+				pk, err := primitives.PrivateKeyFromWif("KznvCNc6Yf4iztSThoMH6oHWzH9EgjfodKxmeuUGPq5DEX5maspS")
 				require.NoError(t, err)
-				assert.NotNil(t, w)
+				assert.NotNil(t, pk)
 				s := &bscript.Script{}
 				require.NoError(t, s.AppendPushDataString("test"))
 				tx.AddOutput(&bt.Output{
 					LockingScript: s,
 				})
-				err = tx.FillAllInputs(context.Background(), &unlocker.Getter{PrivateKey: w.PrivKey})
+				err = tx.FillAllInputs(context.Background(), &unlocker.Getter{PrivateKey: pk})
 				require.NoError(t, err)
 				return tx
 			}(),
@@ -147,11 +148,10 @@ func TestTxJSON_Node_MarshallJSON(t *testing.T) {
 					10000,
 				))
 				require.NoError(t, tx.PayToAddress("n2wmGVP89x3DsLNqk3NvctfQy9m9pvt7mk", 1000))
-				var w *wif.WIF
-				w, err := wif.DecodeWIF("KznvCNc6Yf4iztSThoMH6oHWzH9EgjfodKxmeuUGPq5DEX5maspS")
+				pk, err := primitives.PrivateKeyFromWif("KznvCNc6Yf4iztSThoMH6oHWzH9EgjfodKxmeuUGPq5DEX5maspS")
 				require.NoError(t, err)
-				assert.NotNil(t, w)
-				err = tx.FillAllInputs(context.Background(), &unlocker.Getter{PrivateKey: w.PrivKey})
+				assert.NotNil(t, pk)
+				err = tx.FillAllInputs(context.Background(), &unlocker.Getter{PrivateKey: pk})
 				require.NoError(t, err)
 				return tx
 			}(),
@@ -439,11 +439,10 @@ func TestTxsJSON_Node_MarshallJSON(t *testing.T) {
 					10000,
 				))
 				require.NoError(t, tx.PayToAddress("n2wmGVP89x3DsLNqk3NvctfQy9m9pvt7mk", 1000))
-				var w *wif.WIF
-				w, err := wif.DecodeWIF("KznvCNc6Yf4iztSThoMH6oHWzH9EgjfodKxmeuUGPq5DEX5maspS")
+				pk, err := primitives.PrivateKeyFromWif("KznvCNc6Yf4iztSThoMH6oHWzH9EgjfodKxmeuUGPq5DEX5maspS")
 				require.NoError(t, err)
-				assert.NotNil(t, w)
-				err = tx.FillAllInputs(context.Background(), &unlocker.Getter{PrivateKey: w.PrivKey})
+				assert.NotNil(t, pk)
+				err = tx.FillAllInputs(context.Background(), &unlocker.Getter{PrivateKey: pk})
 				require.NoError(t, err)
 
 				tx2, err := bt.NewTxFromString("020000000117d2011c2a3b8a309d481930bae86e88017b0f55845ada17f96c464684b3af520000000048473044022014a60c3e84cf0160cb7e4ee7d87a3b78c5efb6dd3b66c76970b680affdb95e8f02207f6d9e3268a934e5e278ae513a3bc6dee3bec7bae37204574480305bfb5dea0e41feffffff0240101024010000001976a9149933e4bad50e7dd4b48c1f0be98436ca7d4392a288ac00e1f505000000001976a914abbe187ad301e4326e59587e43d602edd318364e88ac77000000")

--- a/tx_json_test.go
+++ b/tx_json_test.go
@@ -6,10 +6,11 @@ import (
 	"fmt"
 	"testing"
 
+	primitives "github.com/bsv-blockchain/go-sdk/primitives/ec"
+
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/bscript"
 	"github.com/bsv-blockchain/go-bt/v2/unlocker"
-	"github.com/libsv/go-bk/wif"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -31,12 +32,11 @@ func TestTx_JSON(t *testing.T) {
 					2000000,
 				))
 				require.NoError(t, tx.PayToAddress("n2wmGVP89x3DsLNqk3NvctfQy9m9pvt7mk", 1000))
-				var w *wif.WIF
-				w, err := wif.DecodeWIF("KznvCNc6Yf4iztSThoMH6oHWzH9EgjfodKxmeuUGPq5DEX5maspS")
+				pk, err := primitives.PrivateKeyFromWif("KznvCNc6Yf4iztSThoMH6oHWzH9EgjfodKxmeuUGPq5DEX5maspS")
 				require.NoError(t, err)
-				assert.NotNil(t, w)
+				assert.NotNil(t, pk)
 
-				err = tx.FillAllInputs(context.Background(), &unlocker.Getter{PrivateKey: w.PrivKey})
+				err = tx.FillAllInputs(context.Background(), &unlocker.Getter{PrivateKey: pk})
 				require.NoError(t, err)
 				return tx
 			}(),
@@ -50,16 +50,15 @@ func TestTx_JSON(t *testing.T) {
 					2000000,
 				))
 				require.NoError(t, tx.PayToAddress("n2wmGVP89x3DsLNqk3NvctfQy9m9pvt7mk", 1000))
-				var w *wif.WIF
-				w, err := wif.DecodeWIF("KznvCNc6Yf4iztSThoMH6oHWzH9EgjfodKxmeuUGPq5DEX5maspS")
+				pk, err := primitives.PrivateKeyFromWif("KznvCNc6Yf4iztSThoMH6oHWzH9EgjfodKxmeuUGPq5DEX5maspS")
 				require.NoError(t, err)
-				assert.NotNil(t, w)
+				assert.NotNil(t, pk)
 				s := &bscript.Script{}
 				require.NoError(t, s.AppendPushDataString("test"))
 				tx.AddOutput(&bt.Output{
 					LockingScript: s,
 				})
-				err = tx.FillAllInputs(context.Background(), &unlocker.Getter{PrivateKey: w.PrivKey})
+				err = tx.FillAllInputs(context.Background(), &unlocker.Getter{PrivateKey: pk})
 				require.NoError(t, err)
 				return tx
 			}(),
@@ -137,11 +136,10 @@ func TestTx_MarshallJSON(t *testing.T) {
 					10000,
 				))
 				require.NoError(t, tx.PayToAddress("n2wmGVP89x3DsLNqk3NvctfQy9m9pvt7mk", 1000))
-				var w *wif.WIF
-				w, err := wif.DecodeWIF("KznvCNc6Yf4iztSThoMH6oHWzH9EgjfodKxmeuUGPq5DEX5maspS")
+				pk, err := primitives.PrivateKeyFromWif("KznvCNc6Yf4iztSThoMH6oHWzH9EgjfodKxmeuUGPq5DEX5maspS")
 				require.NoError(t, err)
-				assert.NotNil(t, w)
-				err = tx.FillAllInputs(context.Background(), &unlocker.Getter{PrivateKey: w.PrivKey})
+				assert.NotNil(t, pk)
+				err = tx.FillAllInputs(context.Background(), &unlocker.Getter{PrivateKey: pk})
 				require.NoError(t, err)
 				return tx
 			}(),

--- a/tx_output.go
+++ b/tx_output.go
@@ -5,9 +5,10 @@ import (
 	"encoding/hex"
 	"fmt"
 
+	bip32 "github.com/bsv-blockchain/go-sdk/compat/bip32"
+
 	"github.com/bsv-blockchain/go-bt/v2/bscript"
-	"github.com/libsv/go-bk/bip32"
-	"github.com/libsv/go-bk/crypto"
+	crypto "github.com/bsv-blockchain/go-sdk/primitives/hash"
 	"github.com/pkg/errors"
 )
 

--- a/tx_output_test.go
+++ b/tx_output_test.go
@@ -7,10 +7,11 @@ import (
 	"fmt"
 	"testing"
 
+	transaction "github.com/bsv-blockchain/go-sdk/transaction/chaincfg"
+
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/bscript"
-	"github.com/libsv/go-bk/bip32"
-	"github.com/libsv/go-bk/chaincfg"
+	bip32 "github.com/bsv-blockchain/go-sdk/compat/bip32"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -234,7 +235,7 @@ func TestTx_AddP2PKHOutputFromBip32ExtKey(t *testing.T) {
 		_, err := rand.Read(b[:])
 		require.NoError(t, err)
 
-		key, err := bip32.NewMaster(b[:], &chaincfg.TestNet)
+		key, err := bip32.NewMaster(b[:], &transaction.TestNet)
 		require.NoError(t, err)
 
 		derivationPath, err := tx.AddP2PKHOutputFromBip32ExtKey(key, 6000)

--- a/unlocker/simple.go
+++ b/unlocker/simple.go
@@ -8,7 +8,7 @@ import (
 	"github.com/bsv-blockchain/go-bt/v2"
 	"github.com/bsv-blockchain/go-bt/v2/bscript"
 	"github.com/bsv-blockchain/go-bt/v2/sighash"
-	"github.com/libsv/go-bk/bec"
+	bec "github.com/bsv-blockchain/go-sdk/primitives/ec"
 )
 
 var (
@@ -67,7 +67,7 @@ func (l *Simple) UnlockingScript(_ context.Context, tx *bt.Tx, params bt.Unlocke
 		var signature []byte
 
 		if externalSignerFn != nil {
-			signature, err = externalSignerFn(sh, l.PrivateKey.Serialise())
+			signature, err = externalSignerFn(sh, l.PrivateKey.Serialize())
 			if err != nil {
 				return nil, err
 			}
@@ -81,10 +81,10 @@ func (l *Simple) UnlockingScript(_ context.Context, tx *bt.Tx, params bt.Unlocke
 				return nil, err
 			}
 
-			signature = sig.Serialise()
+			signature = sig.Serialize()
 		}
 
-		pubKey := l.PrivateKey.PubKey().SerialiseCompressed()
+		pubKey := l.PrivateKey.PubKey().Compressed()
 
 		uscript, err := bscript.NewP2PKHUnlockingScript(pubKey, signature, params.SigHashFlags)
 		if err != nil {

--- a/unlocker/simple_test.go
+++ b/unlocker/simple_test.go
@@ -8,8 +8,7 @@ import (
 	"github.com/bsv-blockchain/go-bt/v2/bscript"
 	"github.com/bsv-blockchain/go-bt/v2/sighash"
 	"github.com/bsv-blockchain/go-bt/v2/unlocker"
-	"github.com/libsv/go-bk/bec"
-	"github.com/libsv/go-bk/wif"
+	bec "github.com/bsv-blockchain/go-sdk/primitives/ec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -28,11 +27,10 @@ func TestLocalUnlocker_UnlockAllInputs(t *testing.T) {
 	require.NoError(t, err)
 
 	// Our private key
-	var w *wif.WIF
-	w, err = wif.DecodeWIF("cNGwGSc7KRrTmdLUZ54fiSXWbhLNDc2Eg5zNucgQxyQCzuQ5YRDq")
+	pk, err := bec.PrivateKeyFromWif("cNGwGSc7KRrTmdLUZ54fiSXWbhLNDc2Eg5zNucgQxyQCzuQ5YRDq")
 	require.NoError(t, err)
 
-	unlockerVal := unlocker.Getter{PrivateKey: w.PrivKey}
+	unlockerVal := unlocker.Getter{PrivateKey: pk}
 	err = tx.FillAllInputs(context.Background(), &unlockerVal)
 	require.NoError(t, err)
 
@@ -91,11 +89,10 @@ func TestLocalUnlocker_ValidSignature(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			tx := test.tx
 
-			var w *wif.WIF
-			w, err := wif.DecodeWIF("cNGwGSc7KRrTmdLUZ54fiSXWbhLNDc2Eg5zNucgQxyQCzuQ5YRDq")
+			pk, err := bec.PrivateKeyFromWif("cNGwGSc7KRrTmdLUZ54fiSXWbhLNDc2Eg5zNucgQxyQCzuQ5YRDq")
 			require.NoError(t, err)
 
-			unlockerVal := &unlocker.Simple{PrivateKey: w.PrivKey}
+			unlockerVal := &unlocker.Simple{PrivateKey: pk}
 			uscript, err := unlockerVal.UnlockingScript(context.Background(), tx, bt.UnlockerParams{})
 			require.NoError(t, err)
 
@@ -107,10 +104,10 @@ func TestLocalUnlocker_ValidSignature(t *testing.T) {
 			sigBytes := parts[0]
 			publicKeyBytes := parts[1]
 
-			publicKey, err := bec.ParsePubKey(publicKeyBytes, bec.S256())
+			publicKey, err := bec.ParsePubKey(publicKeyBytes)
 			require.NoError(t, err)
 
-			sig, err := bec.ParseDERSignature(sigBytes, bec.S256())
+			sig, err := bec.ParseDERSignature(sigBytes)
 			require.NoError(t, err)
 
 			sh, err := tx.CalcInputSignatureHash(0, sighash.AllForkID)


### PR DESCRIPTION
This pull request refactors the codebase to replace the `libsv/go-bk` library with the `bsv-blockchain/go-sdk` library and makes associated changes to method calls and imports. The updates also include adjustments to method signatures and serialization methods to align with the new library. Below is a summary of the most important changes grouped by theme.

### Library Migration
* Replaced imports of `libsv/go-bk` with corresponding modules from `bsv-blockchain/go-sdk` across multiple files, including `bscript/address.go`, `bscript/interpreter/operations.go`, and various example files. [[1]](diffhunk://#diff-a42d6e7b2475478fd8cd8b3d0db95e6e9e1ae3339f0bf984ff8ba5bcb5079b39L8-R10) [[2]](diffhunk://#diff-8cd4463e84e86de8f46461d3cba23b2fa653862d381fc818a49e2334a8a601a6L15-R16) [[3]](diffhunk://#diff-9161496944d828adfd0dc77e5773322953885d4da1accbf0c8c57538ae279d44R9-R22)

### Method and Function Updates
* Updated method calls for parsing public keys and signatures to remove the curve parameter (`bec.S256()`), as it is no longer required in the new library. [[1]](diffhunk://#diff-a42d6e7b2475478fd8cd8b3d0db95e6e9e1ae3339f0bf984ff8ba5bcb5079b39L100-R103) [[2]](diffhunk://#diff-8cd4463e84e86de8f46461d3cba23b2fa653862d381fc818a49e2334a8a601a6L2012-R2026) [[3]](diffhunk://#diff-8c4f5b64d31b44b128ed2ec2dfc3117f385b8277cf15638e9d916ff220f8abe3L41-R42)
* Changed serialization methods from `SerialiseCompressed` to `Compressed` for public keys and from `Serialise` to `Serialize` for signatures. [[1]](diffhunk://#diff-a42d6e7b2475478fd8cd8b3d0db95e6e9e1ae3339f0bf984ff8ba5bcb5079b39L100-R103) [[2]](diffhunk://#diff-e2932f88750c69567871caec857c592b169714bc8cb14586b2c3a763883cddd5L15-R21)

### Example Code Updates
* Updated example files to use `PrivateKeyFromWif` and `Compressed` methods from the new library instead of the old `wif.DecodeWIF` and `SerialisePubKey` methods. [[1]](diffhunk://#diff-9161496944d828adfd0dc77e5773322953885d4da1accbf0c8c57538ae279d44R9-R22) [[2]](diffhunk://#diff-a85625e4156e8ecbd554b0f8f053f515d42bf50d1b80bbe4ab3d82fd89bcae11L25-R28) [[3]](diffhunk://#diff-0c538691aa8e7919a344f1a7832933bee484f7cc7da26d498b7b4478388869c8L27-R30)

### Code Cleanup
* Removed the unused `InjectExternalVerifySignatureFn` function from `bscript/interpreter/operations.go`.

### Test Updates
* Adjusted test cases to align with the new library's API, including changes to public key parsing and serialization methods. [[1]](diffhunk://#diff-6f7967429e7d6902dc2427559819177f3ddd60abbe1695be97165869e248b3c9L93-R93) [[2]](diffhunk://#diff-8c4f5b64d31b44b128ed2ec2dfc3117f385b8277cf15638e9d916ff220f8abe3L61-R62)