### PR TITLE
Add back function incorrectly removed

### DIFF
--- a/bscript/interpreter/operations.go
+++ b/bscript/interpreter/operations.go
@@ -2291,3 +2291,8 @@ func opcodeCheckMultiSigVerify(op *ParsedOpcode, t *thread) error {
 func success() errs.Error {
 	return errs.NewError(errs.ErrOK, "success")
 }
+
+// InjectExternalVerifySignatureFn allows the injection of an external
+func InjectExternalVerifySignatureFn(fn func(payload, signature, publicKey []byte) bool) {
+	externalVerifySignatureFn = fn
+}


### PR DESCRIPTION
This pull request introduces a new function to enable the injection of an external signature verification function, enhancing the flexibility of the `bscript/interpreter` package.

### New functionality:

* [`bscript/interpreter/operations.go`](diffhunk://#diff-8cd4463e84e86de8f46461d3cba23b2fa653862d381fc818a49e2334a8a601a6R2294-R2298): Added the `InjectExternalVerifySignatureFn` function, which allows external injection of a custom signature verification function. This enables users to provide their own implementation for verifying signatures by passing a function with the signature `func(payload, signature, publicKey []byte) bool`.