### PR TITLE
perf: zero-alloc serialization and sighash caching

### DIFF
--- a/input.go
+++ b/input.go
@@ -344,6 +344,63 @@ func (i *Input) Bytes(clearLockingScript bool, intoBytes ...[]byte) []byte {
 	}...)
 }
 
+// appendTo appends the serialized input to h without allocating.
+// Uses direct slice of previousTxIDHash instead of CloneBytes.
+func (i *Input) appendTo(h []byte, clearLockingScript bool) []byte {
+	if i.previousTxIDHash != nil {
+		h = append(h, i.previousTxIDHash[:]...)
+	}
+
+	h = append(h,
+		byte(i.PreviousTxOutIndex),
+		byte(i.PreviousTxOutIndex>>8),
+		byte(i.PreviousTxOutIndex>>16),
+		byte(i.PreviousTxOutIndex>>24),
+	)
+
+	if clearLockingScript {
+		h = append(h, 0x00)
+	} else if i.UnlockingScript == nil {
+		h = append(h, 0x00)
+	} else {
+		h = VarInt(uint64(len(*i.UnlockingScript))).AppendTo(h)
+		h = append(h, *i.UnlockingScript...)
+	}
+
+	return append(h,
+		byte(i.SequenceNumber),
+		byte(i.SequenceNumber>>8),
+		byte(i.SequenceNumber>>16),
+		byte(i.SequenceNumber>>24),
+	)
+}
+
+// appendExtendedTo appends the extended-format serialized input to h without allocating.
+func (i *Input) appendExtendedTo(h []byte, clearLockingScript bool) []byte {
+	h = i.appendTo(h, clearLockingScript)
+
+	h = append(h,
+		byte(i.PreviousTxSatoshis),
+		byte(i.PreviousTxSatoshis>>8),
+		byte(i.PreviousTxSatoshis>>16),
+		byte(i.PreviousTxSatoshis>>24),
+		byte(i.PreviousTxSatoshis>>32),
+		byte(i.PreviousTxSatoshis>>40),
+		byte(i.PreviousTxSatoshis>>48),
+		byte(i.PreviousTxSatoshis>>56),
+	)
+
+	if i.PreviousTxScript != nil {
+		l := uint64(len(*i.PreviousTxScript))
+		h = VarInt(l).AppendTo(h)
+		h = append(h, *i.PreviousTxScript...)
+	} else {
+		h = append(h, 0x00)
+	}
+
+	return h
+}
+
 // ExtendedBytes encodes the Input into a hex byte array, including the EF transaction format information.
 func (i *Input) ExtendedBytes(clearLockingScript bool, intoBytes ...[]byte) []byte {
 	h := i.Bytes(clearLockingScript, intoBytes...)

--- a/output.go
+++ b/output.go
@@ -113,6 +113,22 @@ func (o *Output) Size() int {
 	return 8 + VarInt(uint64(l)).Length() + l
 }
 
+// appendTo appends the serialized output to h without allocating.
+func (o *Output) appendTo(h []byte) []byte {
+	h = append(h,
+		byte(o.Satoshis),
+		byte(o.Satoshis>>8),
+		byte(o.Satoshis>>16),
+		byte(o.Satoshis>>24),
+		byte(o.Satoshis>>32),
+		byte(o.Satoshis>>40),
+		byte(o.Satoshis>>48),
+		byte(o.Satoshis>>56),
+	)
+	h = VarInt(uint64(len(*o.LockingScript))).AppendTo(h)
+	return append(h, *o.LockingScript...)
+}
+
 // Bytes encodes the Output into a byte array.
 func (o *Output) Bytes(inBytes ...[]byte) []byte {
 	var h []byte
@@ -147,16 +163,8 @@ func (o *Output) Bytes(inBytes ...[]byte) []byte {
 // BytesForSigHash returns the proper serialization
 // of an output to be hashed and signed (sighash).
 func (o *Output) BytesForSigHash() []byte {
-	buf := make([]byte, 0, 8+9+len(*o.LockingScript))
-
-	satoshis := make([]byte, 8)
-	binary.LittleEndian.PutUint64(satoshis, o.Satoshis)
-	buf = append(buf, satoshis...)
-
-	buf = append(buf, VarInt(uint64(len(*o.LockingScript))).Bytes()...)
-	buf = append(buf, *o.LockingScript...)
-
-	return buf
+	buf := make([]byte, 0, o.Size())
+	return o.appendTo(buf)
 }
 
 // NodeJSON returns a wrapped *bt.Output for marshaling/unmarshalling into a node output format.

--- a/signature_hash.go
+++ b/signature_hash.go
@@ -149,8 +149,8 @@ func (tx *Tx) CalcInputPreimageWithCache(inputNumber uint32, sigHashFlag sighash
 // and CalcInputPreimageWithCache. All temp allocations are eliminated by using
 // inline byte appends.
 func (tx *Tx) calcInputPreimage(in *Input, sigHashFlag sighash.Flag,
-	hashPreviousOuts, hashSequence, hashOutputs []byte) ([]byte, error) {
-
+	hashPreviousOuts, hashSequence, hashOutputs []byte,
+) ([]byte, error) {
 	scriptLen := len(*in.PreviousTxScript)
 	// 4 (version) + 32+32 (hashPrevOuts+hashSeq) + 32+4 (outpoint) +
 	// varint(scriptLen) + scriptLen + 8 (value) + 4 (nSeq) + 32 (hashOutputs) +

--- a/signature_hash.go
+++ b/signature_hash.go
@@ -2,7 +2,6 @@ package bt
 
 import (
 	"bytes"
-	"encoding/binary"
 
 	crypto "github.com/bsv-blockchain/go-sdk/primitives/hash"
 
@@ -14,6 +13,29 @@ import (
 var defaultHex = []byte{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 
 type sigHashFunc func(inputIdx uint32, shf sighash.Flag) ([]byte, error)
+
+// SigHashCache holds pre-computed intermediate hash values used during
+// signature hashing. When signing multiple inputs of the same transaction,
+// these hashes are identical across inputs (for the common SighashAll case)
+// and can be computed once instead of O(N) times.
+//
+// Create with tx.NewSigHashCache() and pass to CalcInputPreimageWithCache.
+type SigHashCache struct {
+	PrevOutHash  []byte
+	SequenceHash []byte
+	OutputsHash  []byte
+}
+
+// NewSigHashCache pre-computes the intermediate hashes for the modern
+// (post-fork) sighash algorithm. The returned cache can be passed to
+// CalcInputPreimageWithCache for each input, avoiding O(N²) work.
+func (tx *Tx) NewSigHashCache() *SigHashCache {
+	return &SigHashCache{
+		PrevOutHash:  tx.PreviousOutHash(),
+		SequenceHash: tx.SequenceHash(),
+		OutputsHash:  tx.OutputsHash(-1),
+	}
+}
 
 // sigStrat will decide which tx serialization to use.
 // The legacy serialization will be used for txs pre-fork
@@ -59,86 +81,145 @@ func (tx *Tx) CalcInputSignatureHash(inputNumber uint32, sigHashFlag sighash.Fla
 //
 // see https://github.com/bitcoin-sv/bitcoin-sv/blob/master/doc/abc/replay-protected-sighash.md#digest-algorithm
 func (tx *Tx) CalcInputPreimage(inputNumber uint32, sigHashFlag sighash.Flag) ([]byte, error) {
-	if tx.InputIdx(int(inputNumber)) == nil {
+	in := tx.InputIdx(int(inputNumber))
+	if in == nil {
 		return nil, ErrInputNoExist
 	}
-	in := tx.InputIdx(int(inputNumber))
-
-	if len(in.PreviousTxID()) == 0 {
+	if in.previousTxIDHash == nil {
 		return nil, ErrEmptyPreviousTxID
 	}
 	if in.PreviousTxScript == nil {
 		return nil, ErrEmptyPreviousTxScript
 	}
 
-	hashPreviousOuts := make([]byte, 32)
-	hashSequence := make([]byte, 32)
-	hashOutputs := make([]byte, 32)
+	var hashPreviousOuts, hashSequence, hashOutputs []byte
 
 	if sigHashFlag&sighash.AnyOneCanPay == 0 {
-		// This will be executed in the usual BSV case (where sigHashType = SighashAllForkID)
 		hashPreviousOuts = tx.PreviousOutHash()
 	}
-
 	if sigHashFlag&sighash.AnyOneCanPay == 0 &&
 		(sigHashFlag&31) != sighash.Single &&
 		(sigHashFlag&31) != sighash.None {
-		// This will be executed in the usual BSV case (where sigHashType = SighashAllForkID)
 		hashSequence = tx.SequenceHash()
 	}
-
 	if (sigHashFlag&31) != sighash.Single && (sigHashFlag&31) != sighash.None {
-		// This will be executed in the usual BSV case (where sigHashType = SighashAllForkID)
 		hashOutputs = tx.OutputsHash(-1)
 	} else if (sigHashFlag&31) == sighash.Single && inputNumber < uint32(tx.OutputCount()) {
-		// This will *not* be executed in the usual BSV case (where sigHashType = SighashAllForkID)
 		hashOutputs = tx.OutputsHash(int32(inputNumber))
 	}
 
-	buf := make([]byte, 0, 256)
+	return tx.calcInputPreimage(in, sigHashFlag, hashPreviousOuts, hashSequence, hashOutputs)
+}
+
+// CalcInputPreimageWithCache is like CalcInputPreimage but uses pre-computed
+// hashes from a SigHashCache. Use this when signing multiple inputs to avoid
+// redundant O(N) hash computations per input.
+func (tx *Tx) CalcInputPreimageWithCache(inputNumber uint32, sigHashFlag sighash.Flag, cache *SigHashCache) ([]byte, error) {
+	in := tx.InputIdx(int(inputNumber))
+	if in == nil {
+		return nil, ErrInputNoExist
+	}
+	if in.previousTxIDHash == nil {
+		return nil, ErrEmptyPreviousTxID
+	}
+	if in.PreviousTxScript == nil {
+		return nil, ErrEmptyPreviousTxScript
+	}
+
+	var hashPreviousOuts, hashSequence, hashOutputs []byte
+
+	if sigHashFlag&sighash.AnyOneCanPay == 0 {
+		hashPreviousOuts = cache.PrevOutHash
+	}
+	if sigHashFlag&sighash.AnyOneCanPay == 0 &&
+		(sigHashFlag&31) != sighash.Single &&
+		(sigHashFlag&31) != sighash.None {
+		hashSequence = cache.SequenceHash
+	}
+	if (sigHashFlag&31) != sighash.Single && (sigHashFlag&31) != sighash.None {
+		hashOutputs = cache.OutputsHash
+	} else if (sigHashFlag&31) == sighash.Single && inputNumber < uint32(tx.OutputCount()) {
+		hashOutputs = tx.OutputsHash(int32(inputNumber))
+	}
+
+	return tx.calcInputPreimage(in, sigHashFlag, hashPreviousOuts, hashSequence, hashOutputs)
+}
+
+// calcInputPreimage is the internal implementation shared by CalcInputPreimage
+// and CalcInputPreimageWithCache. All temp allocations are eliminated by using
+// inline byte appends.
+func (tx *Tx) calcInputPreimage(in *Input, sigHashFlag sighash.Flag,
+	hashPreviousOuts, hashSequence, hashOutputs []byte) ([]byte, error) {
+
+	scriptLen := len(*in.PreviousTxScript)
+	// 4 (version) + 32+32 (hashPrevOuts+hashSeq) + 32+4 (outpoint) +
+	// varint(scriptLen) + scriptLen + 8 (value) + 4 (nSeq) + 32 (hashOutputs) +
+	// 4 (locktime) + 4 (sighashtype) = 156 + varint + scriptLen
+	bufSize := 156 + VarInt(uint64(scriptLen)).Length() + scriptLen
+	buf := make([]byte, 0, bufSize)
 
 	// Version
-	v := make([]byte, 4)
-	binary.LittleEndian.PutUint32(v, tx.Version)
-	buf = append(buf, v...)
+	buf = append(buf,
+		byte(tx.Version), byte(tx.Version>>8),
+		byte(tx.Version>>16), byte(tx.Version>>24),
+	)
 
 	// Input previousOuts/nSequence (none/all, depending on flags)
-	buf = append(buf, hashPreviousOuts...)
-	buf = append(buf, hashSequence...)
+	if hashPreviousOuts != nil {
+		buf = append(buf, hashPreviousOuts...)
+	} else {
+		buf = append(buf, make([]byte, 32)...)
+	}
+	if hashSequence != nil {
+		buf = append(buf, hashSequence...)
+	} else {
+		buf = append(buf, make([]byte, 32)...)
+	}
 
-	//  outpoint (32-byte hash + 4-byte little endian)
-	buf = append(buf, in.PreviousTxID()...)
-	oi := make([]byte, 4)
-	binary.LittleEndian.PutUint32(oi, in.PreviousTxOutIndex)
-	buf = append(buf, oi...)
+	// outpoint (32-byte hash + 4-byte little endian)
+	buf = append(buf, in.previousTxIDHash[:]...)
+	buf = append(buf,
+		byte(in.PreviousTxOutIndex), byte(in.PreviousTxOutIndex>>8),
+		byte(in.PreviousTxOutIndex>>16), byte(in.PreviousTxOutIndex>>24),
+	)
 
-	// scriptCode of the input (serialized as scripts inside CTxOuts)
-	buf = append(buf, VarInt(uint64(len(*in.PreviousTxScript))).Bytes()...)
+	// scriptCode of the input
+	buf = VarInt(uint64(scriptLen)).AppendTo(buf)
 	buf = append(buf, *in.PreviousTxScript...)
 
 	// value of the output spent by this input (8-byte little endian)
-	sat := make([]byte, 8)
-	binary.LittleEndian.PutUint64(sat, in.PreviousTxSatoshis)
-	buf = append(buf, sat...)
+	buf = append(buf,
+		byte(in.PreviousTxSatoshis), byte(in.PreviousTxSatoshis>>8),
+		byte(in.PreviousTxSatoshis>>16), byte(in.PreviousTxSatoshis>>24),
+		byte(in.PreviousTxSatoshis>>32), byte(in.PreviousTxSatoshis>>40),
+		byte(in.PreviousTxSatoshis>>48), byte(in.PreviousTxSatoshis>>56),
+	)
 
-	// nSequence of the input (4-byte little endian)
-	seq := make([]byte, 4)
-	binary.LittleEndian.PutUint32(seq, in.SequenceNumber)
-	buf = append(buf, seq...)
+	// nSequence of the input
+	buf = append(buf,
+		byte(in.SequenceNumber), byte(in.SequenceNumber>>8),
+		byte(in.SequenceNumber>>16), byte(in.SequenceNumber>>24),
+	)
 
 	// Outputs (none/one/all, depending on flags)
-	buf = append(buf, hashOutputs...)
+	if hashOutputs != nil {
+		buf = append(buf, hashOutputs...)
+	} else {
+		buf = append(buf, make([]byte, 32)...)
+	}
 
 	// LockTime
-	lt := make([]byte, 4)
-	binary.LittleEndian.PutUint32(lt, tx.LockTime)
-	buf = append(buf, lt...)
+	buf = append(buf,
+		byte(tx.LockTime), byte(tx.LockTime>>8),
+		byte(tx.LockTime>>16), byte(tx.LockTime>>24),
+	)
 
 	// sighashType
-	// writer.writeUInt32LE(sighashType >>> 0)
-	st := make([]byte, 4)
-	binary.LittleEndian.PutUint32(st, uint32(sigHashFlag)>>0)
-	buf = append(buf, st...)
+	shf := uint32(sigHashFlag)
+	buf = append(buf,
+		byte(shf), byte(shf>>8),
+		byte(shf>>16), byte(shf>>24),
+	)
 
 	return buf, nil
 }
@@ -148,12 +229,11 @@ func (tx *Tx) CalcInputPreimage(inputNumber uint32, sigHashFlag sighash.Flag) ([
 //
 // see https://wiki.bitcoinsv.io/index.php/Legacy_Sighash_Algorithm
 func (tx *Tx) CalcInputPreimageLegacy(inputNumber uint32, shf sighash.Flag) ([]byte, error) {
-	if tx.InputIdx(int(inputNumber)) == nil {
+	in := tx.InputIdx(int(inputNumber))
+	if in == nil {
 		return nil, ErrInputNoExist
 	}
-	in := tx.InputIdx(int(inputNumber))
-
-	if len(in.PreviousTxID()) == 0 {
+	if in.previousTxIDHash == nil {
 		return nil, ErrEmptyPreviousTxID
 	}
 	if in.PreviousTxScript == nil {
@@ -184,7 +264,7 @@ func (tx *Tx) CalcInputPreimageLegacy(inputNumber uint32, shf sighash.Flag) ([]b
 		return defaultHex, nil
 	}
 
-	txCopy := tx.Clone()
+	txCopy := tx.ShallowClone()
 
 	for i := range txCopy.Inputs {
 		if i == int(inputNumber) {
@@ -220,61 +300,81 @@ func (tx *Tx) CalcInputPreimageLegacy(inputNumber uint32, shf sighash.Flag) ([]b
 		txCopy.Inputs = txCopy.Inputs[inputNumber : inputNumber+1]
 	}
 
-	buf := make([]byte, 0)
+	// Estimate buffer size: version(4) + varint + N*(32+4+varint+script+4) + varint + outputs + locktime(4) + sighash(4)
+	buf := make([]byte, 0, txCopy.Size()+8)
 
 	// Version
-	v := make([]byte, 4)
-	binary.LittleEndian.PutUint32(v, tx.Version)
-	buf = append(buf, v...)
+	buf = append(buf,
+		byte(tx.Version), byte(tx.Version>>8),
+		byte(tx.Version>>16), byte(tx.Version>>24),
+	)
 
-	buf = append(buf, VarInt(uint64(len(txCopy.Inputs))).Bytes()...)
+	buf = VarInt(uint64(len(txCopy.Inputs))).AppendTo(buf)
 	for _, in := range txCopy.Inputs {
-		buf = append(buf, in.PreviousTxID()...)
+		if in.previousTxIDHash != nil {
+			buf = append(buf, in.previousTxIDHash[:]...)
+		}
 
-		oi := make([]byte, 4)
-		binary.LittleEndian.PutUint32(oi, in.PreviousTxOutIndex)
-		buf = append(buf, oi...)
+		buf = append(buf,
+			byte(in.PreviousTxOutIndex), byte(in.PreviousTxOutIndex>>8),
+			byte(in.PreviousTxOutIndex>>16), byte(in.PreviousTxOutIndex>>24),
+		)
 
-		buf = append(buf, VarInt(uint64(len(*in.PreviousTxScript))).Bytes()...)
+		buf = VarInt(uint64(len(*in.PreviousTxScript))).AppendTo(buf)
 		buf = append(buf, *in.PreviousTxScript...)
 
-		sq := make([]byte, 4)
-		binary.LittleEndian.PutUint32(sq, in.SequenceNumber)
-		buf = append(buf, sq...)
+		buf = append(buf,
+			byte(in.SequenceNumber), byte(in.SequenceNumber>>8),
+			byte(in.SequenceNumber>>16), byte(in.SequenceNumber>>24),
+		)
 	}
 
-	buf = append(buf, VarInt(uint64(len(txCopy.Outputs))).Bytes()...)
+	buf = VarInt(uint64(len(txCopy.Outputs))).AppendTo(buf)
 	for _, out := range txCopy.Outputs {
-		st := make([]byte, 8)
-		binary.LittleEndian.PutUint64(st, out.Satoshis)
-		buf = append(buf, st...)
+		buf = append(buf,
+			byte(out.Satoshis), byte(out.Satoshis>>8),
+			byte(out.Satoshis>>16), byte(out.Satoshis>>24),
+			byte(out.Satoshis>>32), byte(out.Satoshis>>40),
+			byte(out.Satoshis>>48), byte(out.Satoshis>>56),
+		)
 
-		buf = append(buf, VarInt(uint64(len(*out.LockingScript))).Bytes()...)
+		buf = VarInt(uint64(len(*out.LockingScript))).AppendTo(buf)
 		buf = append(buf, *out.LockingScript...)
 	}
 
 	// LockTime
-	lt := make([]byte, 4)
-	binary.LittleEndian.PutUint32(lt, tx.LockTime)
-	buf = append(buf, lt...)
+	buf = append(buf,
+		byte(tx.LockTime), byte(tx.LockTime>>8),
+		byte(tx.LockTime>>16), byte(tx.LockTime>>24),
+	)
 
-	sh := make([]byte, 4)
-	binary.LittleEndian.PutUint32(sh, uint32(shf)>>0)
-	return append(buf, sh...), nil
+	// sighash flag
+	s := uint32(shf)
+	buf = append(buf,
+		byte(s), byte(s>>8),
+		byte(s>>16), byte(s>>24),
+	)
+
+	return buf, nil
 }
 
 // OutputsHash returns a bytes slice of the requested output, used for generating
 // the txs signature hash. If n is -1, it will create the byte slice from all outputs.
 func (tx *Tx) OutputsHash(n int32) []byte {
-	buf := make([]byte, 0)
-
 	if n == -1 {
+		// Pre-compute total size for all outputs
+		size := 0
 		for _, out := range tx.Outputs {
-			buf = append(buf, out.BytesForSigHash()...)
+			size += out.Size()
 		}
-	} else {
-		buf = append(buf, tx.Outputs[n].BytesForSigHash()...)
+		buf := make([]byte, 0, size)
+		for _, out := range tx.Outputs {
+			buf = out.appendTo(buf)
+		}
+		return crypto.Sha256d(buf)
 	}
 
+	buf := make([]byte, 0, tx.Outputs[n].Size())
+	buf = tx.Outputs[n].appendTo(buf)
 	return crypto.Sha256d(buf)
 }

--- a/signature_hash_benchmark_test.go
+++ b/signature_hash_benchmark_test.go
@@ -1,0 +1,103 @@
+package bt_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bsv-blockchain/go-bt/v2"
+	"github.com/bsv-blockchain/go-bt/v2/bscript"
+	"github.com/bsv-blockchain/go-bt/v2/sighash"
+)
+
+func buildSigningTx(b testing.TB, nInputs int) *bt.Tx {
+	b.Helper()
+	tx := bt.NewTx()
+	for i := 0; i < nInputs; i++ {
+		require.NoError(b, tx.From(
+			"b7b0650a7c3a1bd4f7571b4c1e38f05171b565b8e28b2e337031ee31e9fa8eb6",
+			uint32(i),
+			"76a914167c3e911a14a92760b81334d01045da61e9681888ac",
+			100000,
+		))
+	}
+	tx.AddOutput(&bt.Output{
+		Satoshis:      99000,
+		LockingScript: bscript.NewFromBytes([]byte{0x76, 0xa9, 0x14}),
+	})
+	return tx
+}
+
+// BenchmarkCalcInputPreimage benchmarks the modern sighash path.
+func BenchmarkCalcInputPreimage(b *testing.B) {
+	for _, nInputs := range []int{1, 5, 20, 100} {
+		tx := buildSigningTx(b, nInputs)
+
+		// Benchmark signing ALL inputs (the real-world hot path)
+		b.Run(fmt.Sprintf("AllInputs_%d_nocache", nInputs), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				for j := 0; j < nInputs; j++ {
+					_, _ = tx.CalcInputPreimage(uint32(j), sighash.AllForkID)
+				}
+			}
+		})
+
+		b.Run(fmt.Sprintf("AllInputs_%d_cached", nInputs), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				cache := tx.NewSigHashCache()
+				for j := 0; j < nInputs; j++ {
+					_, _ = tx.CalcInputPreimageWithCache(uint32(j), sighash.AllForkID, cache)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkCalcInputPreimageLegacy benchmarks the legacy sighash path.
+func BenchmarkCalcInputPreimageLegacy(b *testing.B) {
+	for _, nInputs := range []int{1, 5, 20} {
+		tx := buildSigningTx(b, nInputs)
+
+		b.Run(fmt.Sprintf("AllInputs_%d", nInputs), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				for j := 0; j < nInputs; j++ {
+					_, _ = tx.CalcInputPreimageLegacy(uint32(j), sighash.All)
+				}
+			}
+		})
+	}
+}
+
+// TestCalcInputPreimageWithCache_MatchesUncached verifies the cached path produces
+// identical preimages to the uncached path for all inputs.
+func TestCalcInputPreimageWithCache_MatchesUncached(t *testing.T) {
+	for _, nInputs := range []int{1, 3, 10} {
+		tx := buildSigningTx(t, nInputs)
+		cache := tx.NewSigHashCache()
+
+		for j := 0; j < nInputs; j++ {
+			expected, err := tx.CalcInputPreimage(uint32(j), sighash.AllForkID)
+			require.NoError(t, err)
+
+			got, err := tx.CalcInputPreimageWithCache(uint32(j), sighash.AllForkID, cache)
+			require.NoError(t, err)
+
+			require.Equal(t, expected, got, "input %d: cached preimage mismatch", j)
+		}
+	}
+}
+
+// TestOutputsHashOptimized verifies OutputsHash still returns correct results after optimization.
+func TestOutputsHashOptimized(t *testing.T) {
+	tx := buildSigningTx(t, 3)
+
+	// Capture the result before and after (same code, just verifying we didn't break anything)
+	hash1 := tx.OutputsHash(-1)
+	hash2 := tx.OutputsHash(-1)
+	require.Equal(t, hash1, hash2)
+
+	// Single output hash
+	hash3 := tx.OutputsHash(0)
+	require.Len(t, hash3, 32)
+}

--- a/tx.go
+++ b/tx.go
@@ -376,6 +376,13 @@ func (tx *Tx) Bytes() []byte {
 	return tx.toBytesHelper(0, nil, false)
 }
 
+// AppendBytes appends the serialized transaction to dst and returns the
+// extended slice. When dst has sufficient capacity (e.g. pre-allocated via
+// tx.Size()), this method performs zero heap allocations.
+func (tx *Tx) AppendBytes(dst []byte) []byte {
+	return tx.appendBytesHelper(dst, 0, nil, false)
+}
+
 // ExtendedBytes outputs the transaction into a byte array in extended format
 // (with PreviousTxSatoshis and PreviousTXScript included)
 func (tx *Tx) ExtendedBytes() []byte {
@@ -527,46 +534,54 @@ func (tt *Txs) NodeJSON() interface{} {
 }
 
 // toBytesHelper encodes the transaction into a byte array.
+// It pre-computes the exact size to allocate once, then delegates
+// to appendBytesHelper for zero-alloc serialization.
 func (tx *Tx) toBytesHelper(index int, lockingScript []byte, extended bool) []byte {
-	h := make([]byte, 0, 1024)
-	// this is faster than using LittleEndianBytes, since we do not malloc a new byte slice
-	h = append(h, []byte{
+	h := make([]byte, 0, tx.Size())
+	return tx.appendBytesHelper(h, index, lockingScript, extended)
+}
+
+// appendBytesHelper appends the serialized transaction to h without allocating
+// (provided h has sufficient capacity). This is the core serialization method
+// shared by both Bytes() and AppendBytes().
+func (tx *Tx) appendBytesHelper(h []byte, index int, lockingScript []byte, extended bool) []byte {
+	h = append(h,
 		byte(tx.Version),
-		byte(tx.Version >> 8),
-		byte(tx.Version >> 16),
-		byte(tx.Version >> 24),
-	}...)
+		byte(tx.Version>>8),
+		byte(tx.Version>>16),
+		byte(tx.Version>>24),
+	)
 
 	if extended {
-		h = append(h, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0xEF}...)
+		h = append(h, 0x00, 0x00, 0x00, 0x00, 0x00, 0xEF)
 	}
 
-	h = append(h, VarInt(uint64(len(tx.Inputs))).Bytes()...)
+	h = VarInt(uint64(len(tx.Inputs))).AppendTo(h)
 
 	for i, in := range tx.Inputs {
 		if i == index && lockingScript != nil {
-			h = append(h, VarInt(uint64(len(lockingScript))).Bytes()...)
+			h = VarInt(uint64(len(lockingScript))).AppendTo(h)
 			h = append(h, lockingScript...)
 		} else {
 			if extended {
-				h = in.ExtendedBytes(lockingScript != nil, h)
+				h = in.appendExtendedTo(h, lockingScript != nil)
 			} else {
-				h = in.Bytes(lockingScript != nil, h)
+				h = in.appendTo(h, lockingScript != nil)
 			}
 		}
 	}
 
-	h = append(h, VarInt(uint64(len(tx.Outputs))).Bytes()...)
+	h = VarInt(uint64(len(tx.Outputs))).AppendTo(h)
 	for _, out := range tx.Outputs {
-		h = out.Bytes(h)
+		h = out.appendTo(h)
 	}
 
-	return append(h, []byte{
+	return append(h,
 		byte(tx.LockTime),
-		byte(tx.LockTime >> 8),
-		byte(tx.LockTime >> 16),
-		byte(tx.LockTime >> 24),
-	}...)
+		byte(tx.LockTime>>8),
+		byte(tx.LockTime>>16),
+		byte(tx.LockTime>>24),
+	)
 }
 
 // TxSize contains the size breakdown of a transaction

--- a/tx_benchmark_test.go
+++ b/tx_benchmark_test.go
@@ -227,6 +227,123 @@ func BenchmarkWriteTo(b *testing.B) {
 	})
 }
 
+// TestAppendBytes_MatchesBytes verifies AppendBytes produces identical output to Bytes().
+func TestAppendBytes_MatchesBytes(t *testing.T) {
+	tests := []struct {
+		name    string
+		buildTx func(t *testing.T) *bt.Tx
+	}{
+		{
+			name: "real tx with 3 inputs 2 outputs",
+			buildTx: func(t *testing.T) *bt.Tx {
+				tx, err := bt.NewTxFromString("0200000003a9bc457fdc6a54d99300fb137b23714d860c350a9d19ff0f571e694a419ff3a0010000006b48304502210086c83beb2b2663e4709a583d261d75be538aedcafa7766bd983e5c8db2f8b2fc02201a88b178624ab0ad1748b37c875f885930166237c88f5af78ee4e61d337f935f412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff0092bb9a47e27bf64fc98f557c530c04d9ac25e2f2a8b600e92a0b1ae7c89c20010000006b483045022100f06b3db1c0a11af348401f9cebe10ae2659d6e766a9dcd9e3a04690ba10a160f02203f7fbd7dfcfc70863aface1a306fcc91bbadf6bc884c21a55ef0d32bd6b088c8412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff9d0d4554fa692420a0830ca614b6c60f1bf8eaaa21afca4aa8c99fb052d9f398000000006b483045022100d920f2290548e92a6235f8b2513b7f693a64a0d3fa699f81a034f4b4608ff82f0220767d7d98025aff3c7bd5f2a66aab6a824f5990392e6489aae1e1ae3472d8dffb412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff02807c814a000000001976a9143a6bf34ebfcf30e8541bbb33a7882845e5a29cb488ac76b0e60e000000001976a914bd492b67f90cb85918494767ebb23102c4f06b7088ac67000000")
+				require.NoError(t, err)
+				return tx
+			},
+		},
+		{
+			name: "coinbase tx",
+			buildTx: func(t *testing.T) *bt.Tx {
+				tx, err := bt.NewTxFromString("01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0704ffff001d0104ffffffff0100f2052a0100000043410496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858eeac00000000")
+				require.NoError(t, err)
+				return tx
+			},
+		},
+		{
+			name: "single input single output",
+			buildTx: func(t *testing.T) *bt.Tx {
+				tx := bt.NewTx()
+				require.NoError(t, tx.From("b7b0650a7c3a1bd4f7571b4c1e38f05171b565b8e28b2e337031ee31e9fa8eb6", 0, "76a914167c3e911a14a92760b81334d01045da61e9681888ac", 100000))
+				tx.AddOutput(&bt.Output{
+					Satoshis:      99000,
+					LockingScript: bscript.NewFromBytes([]byte{0x76, 0xa9, 0x14}),
+				})
+				return tx
+			},
+		},
+		{
+			name: "large script output",
+			buildTx: func(t *testing.T) *bt.Tx {
+				tx := bt.NewTx()
+				require.NoError(t, tx.From("b7b0650a7c3a1bd4f7571b4c1e38f05171b565b8e28b2e337031ee31e9fa8eb6", 0, "76a914167c3e911a14a92760b81334d01045da61e9681888ac", 100000))
+				bigScript := make([]byte, 100000)
+				_, _ = rand.Read(bigScript)
+				tx.AddOutput(&bt.Output{
+					Satoshis:      1,
+					LockingScript: bscript.NewFromBytes(bigScript),
+				})
+				return tx
+			},
+		},
+		{
+			name: "empty unlocking scripts",
+			buildTx: func(t *testing.T) *bt.Tx {
+				tx := bt.NewTx()
+				tx.AddOutput(&bt.Output{
+					Satoshis:      1000,
+					LockingScript: bscript.NewFromBytes([]byte{0x51}),
+				})
+				return tx
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tx := tt.buildTx(t)
+			expected := tx.Bytes()
+
+			// AppendBytes to nil should produce same bytes
+			got := tx.AppendBytes(nil)
+			require.Equal(t, expected, got)
+
+			// AppendBytes to pre-allocated buffer should produce same bytes
+			buf := make([]byte, 0, tx.Size())
+			got = tx.AppendBytes(buf)
+			require.Equal(t, expected, got)
+		})
+	}
+}
+
+// TestAppendBytes_ZeroAllocs verifies AppendBytes does not allocate when given a sufficiently sized buffer.
+func TestAppendBytes_ZeroAllocs(t *testing.T) {
+	tx, err := bt.NewTxFromString("0200000003a9bc457fdc6a54d99300fb137b23714d860c350a9d19ff0f571e694a419ff3a0010000006b48304502210086c83beb2b2663e4709a583d261d75be538aedcafa7766bd983e5c8db2f8b2fc02201a88b178624ab0ad1748b37c875f885930166237c88f5af78ee4e61d337f935f412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff0092bb9a47e27bf64fc98f557c530c04d9ac25e2f2a8b600e92a0b1ae7c89c20010000006b483045022100f06b3db1c0a11af348401f9cebe10ae2659d6e766a9dcd9e3a04690ba10a160f02203f7fbd7dfcfc70863aface1a306fcc91bbadf6bc884c21a55ef0d32bd6b088c8412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff9d0d4554fa692420a0830ca614b6c60f1bf8eaaa21afca4aa8c99fb052d9f398000000006b483045022100d920f2290548e92a6235f8b2513b7f693a64a0d3fa699f81a034f4b4608ff82f0220767d7d98025aff3c7bd5f2a66aab6a824f5990392e6489aae1e1ae3472d8dffb412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff02807c814a000000001976a9143a6bf34ebfcf30e8541bbb33a7882845e5a29cb488ac76b0e60e000000001976a914bd492b67f90cb85918494767ebb23102c4f06b7088ac67000000")
+	require.NoError(t, err)
+
+	buf := make([]byte, 0, tx.Size())
+	allocs := testing.AllocsPerRun(100, func() {
+		buf = tx.AppendBytes(buf[:0])
+	})
+	require.Equal(t, float64(0), allocs, "AppendBytes with pre-sized buffer should be zero-alloc")
+}
+
+// TestBytes_ExactAlloc verifies that Bytes() allocates exactly the right size (no wasted capacity).
+func TestBytes_ExactAlloc(t *testing.T) {
+	tx, err := bt.NewTxFromString("0200000003a9bc457fdc6a54d99300fb137b23714d860c350a9d19ff0f571e694a419ff3a0010000006b48304502210086c83beb2b2663e4709a583d261d75be538aedcafa7766bd983e5c8db2f8b2fc02201a88b178624ab0ad1748b37c875f885930166237c88f5af78ee4e61d337f935f412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff0092bb9a47e27bf64fc98f557c530c04d9ac25e2f2a8b600e92a0b1ae7c89c20010000006b483045022100f06b3db1c0a11af348401f9cebe10ae2659d6e766a9dcd9e3a04690ba10a160f02203f7fbd7dfcfc70863aface1a306fcc91bbadf6bc884c21a55ef0d32bd6b088c8412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff9d0d4554fa692420a0830ca614b6c60f1bf8eaaa21afca4aa8c99fb052d9f398000000006b483045022100d920f2290548e92a6235f8b2513b7f693a64a0d3fa699f81a034f4b4608ff82f0220767d7d98025aff3c7bd5f2a66aab6a824f5990392e6489aae1e1ae3472d8dffb412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff02807c814a000000001976a9143a6bf34ebfcf30e8541bbb33a7882845e5a29cb488ac76b0e60e000000001976a914bd492b67f90cb85918494767ebb23102c4f06b7088ac67000000")
+	require.NoError(t, err)
+
+	b := tx.Bytes()
+	require.Equal(t, len(b), cap(b), "Bytes() should allocate exactly the right capacity, got len=%d cap=%d", len(b), cap(b))
+}
+
+// BenchmarkAppendBytes benchmarks the zero-alloc AppendBytes method.
+func BenchmarkAppendBytes(b *testing.B) {
+	tx, _ := bt.NewTxFromString("0200000003a9bc457fdc6a54d99300fb137b23714d860c350a9d19ff0f571e694a419ff3a0010000006b48304502210086c83beb2b2663e4709a583d261d75be538aedcafa7766bd983e5c8db2f8b2fc02201a88b178624ab0ad1748b37c875f885930166237c88f5af78ee4e61d337f935f412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff0092bb9a47e27bf64fc98f557c530c04d9ac25e2f2a8b600e92a0b1ae7c89c20010000006b483045022100f06b3db1c0a11af348401f9cebe10ae2659d6e766a9dcd9e3a04690ba10a160f02203f7fbd7dfcfc70863aface1a306fcc91bbadf6bc884c21a55ef0d32bd6b088c8412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff9d0d4554fa692420a0830ca614b6c60f1bf8eaaa21afca4aa8c99fb052d9f398000000006b483045022100d920f2290548e92a6235f8b2513b7f693a64a0d3fa699f81a034f4b4608ff82f0220767d7d98025aff3c7bd5f2a66aab6a824f5990392e6489aae1e1ae3472d8dffb412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff02807c814a000000001976a9143a6bf34ebfcf30e8541bbb33a7882845e5a29cb488ac76b0e60e000000001976a914bd492b67f90cb85918494767ebb23102c4f06b7088ac67000000")
+
+	buf := make([]byte, 0, tx.Size())
+	b.Run("AppendBytes_reuse", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			buf = tx.AppendBytes(buf[:0])
+		}
+	})
+
+	b.Run("Bytes", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = tx.Bytes()
+		}
+	})
+}
+
 // BenchmarkShallowClone benchmarks the ShallowClone method of a transaction.
 func BenchmarkShallowClone(b *testing.B) {
 	tx, _ := bt.NewTxFromString("0200000003a9bc457fdc6a54d99300fb137b23714d860c350a9d19ff0f571e694a419ff3a0010000006b48304502210086c83beb2b2663e4709a583d261d75be538aedcafa7766bd983e5c8db2f8b2fc02201a88b178624ab0ad1748b37c875f885930166237c88f5af78ee4e61d337f935f412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff0092bb9a47e27bf64fc98f557c530c04d9ac25e2f2a8b600e92a0b1ae7c89c20010000006b483045022100f06b3db1c0a11af348401f9cebe10ae2659d6e766a9dcd9e3a04690ba10a160f02203f7fbd7dfcfc70863aface1a306fcc91bbadf6bc884c21a55ef0d32bd6b088c8412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff9d0d4554fa692420a0830ca614b6c60f1bf8eaaa21afca4aa8c99fb052d9f398000000006b483045022100d920f2290548e92a6235f8b2513b7f693a64a0d3fa699f81a034f4b4608ff82f0220767d7d98025aff3c7bd5f2a66aab6a824f5990392e6489aae1e1ae3472d8dffb412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff02807c814a000000001976a9143a6bf34ebfcf30e8541bbb33a7882845e5a29cb488ac76b0e60e000000001976a914bd492b67f90cb85918494767ebb23102c4f06b7088ac67000000")

--- a/tx_benchmark_test.go
+++ b/tx_benchmark_test.go
@@ -191,7 +191,7 @@ func TestAppendBytes_ZeroAllocs(t *testing.T) {
 	allocs := testing.AllocsPerRun(100, func() {
 		buf = tx.AppendBytes(buf[:0])
 	})
-	require.Equal(t, float64(0), allocs, "AppendBytes with pre-sized buffer should be zero-alloc")
+	require.InDelta(t, 0, allocs, 0, "AppendBytes with pre-sized buffer should be zero-alloc")
 }
 
 // TestBytes_ExactAlloc verifies that Bytes() allocates exactly the right size (no wasted capacity).

--- a/tx_benchmark_test.go
+++ b/tx_benchmark_test.go
@@ -12,9 +12,68 @@ import (
 	"github.com/bsv-blockchain/go-bt/v2/bscript"
 )
 
+// testTxHex is a real 3-input 2-output transaction used across benchmarks and tests.
+const testTxHex = "0200000003a9bc457fdc6a54d99300fb137b23714d860c350a9d19ff0f571e694a419ff3a0010000006b48304502210086c83beb2b2663e4709a583d261d75be538aedcafa7766bd983e5c8db2f8b2fc02201a88b178624ab0ad1748b37c875f885930166237c88f5af78ee4e61d337f935f412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff0092bb9a47e27bf64fc98f557c530c04d9ac25e2f2a8b600e92a0b1ae7c89c20010000006b483045022100f06b3db1c0a11af348401f9cebe10ae2659d6e766a9dcd9e3a04690ba10a160f02203f7fbd7dfcfc70863aface1a306fcc91bbadf6bc884c21a55ef0d32bd6b088c8412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff9d0d4554fa692420a0830ca614b6c60f1bf8eaaa21afca4aa8c99fb052d9f398000000006b483045022100d920f2290548e92a6235f8b2513b7f693a64a0d3fa699f81a034f4b4608ff82f0220767d7d98025aff3c7bd5f2a66aab6a824f5990392e6489aae1e1ae3472d8dffb412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff02807c814a000000001976a9143a6bf34ebfcf30e8541bbb33a7882845e5a29cb488ac76b0e60e000000001976a914bd492b67f90cb85918494767ebb23102c4f06b7088ac67000000"
+
+// coinbaseTxHex is a coinbase transaction used in serialization tests.
+const coinbaseTxHex = "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0704ffff001d0104ffffffff0100f2052a0100000043410496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858eeac00000000"
+
+// txShapeTests returns a standard set of transaction shapes for serialization tests.
+func txShapeTests(t testing.TB) []struct {
+	name string
+	tx   *bt.Tx
+} {
+	t.Helper()
+
+	realTx, err := bt.NewTxFromString(testTxHex)
+	require.NoError(t, err)
+
+	coinbaseTx, err := bt.NewTxFromString(coinbaseTxHex)
+	require.NoError(t, err)
+
+	singleTx := bt.NewTx()
+	require.NoError(t, singleTx.From("b7b0650a7c3a1bd4f7571b4c1e38f05171b565b8e28b2e337031ee31e9fa8eb6", 0, "76a914167c3e911a14a92760b81334d01045da61e9681888ac", 100000))
+	singleTx.AddOutput(&bt.Output{
+		Satoshis:      99000,
+		LockingScript: bscript.NewFromBytes([]byte{0x76, 0xa9, 0x14}),
+	})
+
+	largeTx := bt.NewTx()
+	require.NoError(t, largeTx.From("b7b0650a7c3a1bd4f7571b4c1e38f05171b565b8e28b2e337031ee31e9fa8eb6", 0, "76a914167c3e911a14a92760b81334d01045da61e9681888ac", 100000))
+	bigScript := make([]byte, 100000)
+	_, _ = rand.Read(bigScript)
+	largeTx.AddOutput(&bt.Output{
+		Satoshis:      1,
+		LockingScript: bscript.NewFromBytes(bigScript),
+	})
+
+	emptyTx := bt.NewTx()
+	emptyTx.AddOutput(&bt.Output{
+		Satoshis:      1000,
+		LockingScript: bscript.NewFromBytes([]byte{0x51}),
+	})
+
+	return []struct {
+		name string
+		tx   *bt.Tx
+	}{
+		{"real tx with 3 inputs 2 outputs", realTx},
+		{"coinbase tx", coinbaseTx},
+		{"single input single output", singleTx},
+		{"large script output", largeTx},
+		{"empty unlocking scripts", emptyTx},
+	}
+}
+
+// mustParseTx parses testTxHex for use in benchmarks.
+func mustParseTx() *bt.Tx {
+	tx, _ := bt.NewTxFromString(testTxHex)
+	return tx
+}
+
 // BenchmarkBytes benchmarks the Bytes method of a transaction.
 func BenchmarkBytes(b *testing.B) {
-	tx, _ := bt.NewTxFromString("0200000003a9bc457fdc6a54d99300fb137b23714d860c350a9d19ff0f571e694a419ff3a0010000006b48304502210086c83beb2b2663e4709a583d261d75be538aedcafa7766bd983e5c8db2f8b2fc02201a88b178624ab0ad1748b37c875f885930166237c88f5af78ee4e61d337f935f412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff0092bb9a47e27bf64fc98f557c530c04d9ac25e2f2a8b600e92a0b1ae7c89c20010000006b483045022100f06b3db1c0a11af348401f9cebe10ae2659d6e766a9dcd9e3a04690ba10a160f02203f7fbd7dfcfc70863aface1a306fcc91bbadf6bc884c21a55ef0d32bd6b088c8412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff9d0d4554fa692420a0830ca614b6c60f1bf8eaaa21afca4aa8c99fb052d9f398000000006b483045022100d920f2290548e92a6235f8b2513b7f693a64a0d3fa699f81a034f4b4608ff82f0220767d7d98025aff3c7bd5f2a66aab6a824f5990392e6489aae1e1ae3472d8dffb412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff02807c814a000000001976a9143a6bf34ebfcf30e8541bbb33a7882845e5a29cb488ac76b0e60e000000001976a914bd492b67f90cb85918494767ebb23102c4f06b7088ac67000000")
+	tx := mustParseTx()
 
 	b.Run("toBytesHelper", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
@@ -26,7 +85,7 @@ func BenchmarkBytes(b *testing.B) {
 
 // BenchmarkClone benchmarks the Clone method of a transaction.
 func BenchmarkClone(b *testing.B) {
-	tx, _ := bt.NewTxFromString("0200000003a9bc457fdc6a54d99300fb137b23714d860c350a9d19ff0f571e694a419ff3a0010000006b48304502210086c83beb2b2663e4709a583d261d75be538aedcafa7766bd983e5c8db2f8b2fc02201a88b178624ab0ad1748b37c875f885930166237c88f5af78ee4e61d337f935f412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff0092bb9a47e27bf64fc98f557c530c04d9ac25e2f2a8b600e92a0b1ae7c89c20010000006b483045022100f06b3db1c0a11af348401f9cebe10ae2659d6e766a9dcd9e3a04690ba10a160f02203f7fbd7dfcfc70863aface1a306fcc91bbadf6bc884c21a55ef0d32bd6b088c8412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff9d0d4554fa692420a0830ca614b6c60f1bf8eaaa21afca4aa8c99fb052d9f398000000006b483045022100d920f2290548e92a6235f8b2513b7f693a64a0d3fa699f81a034f4b4608ff82f0220767d7d98025aff3c7bd5f2a66aab6a824f5990392e6489aae1e1ae3472d8dffb412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff02807c814a000000001976a9143a6bf34ebfcf30e8541bbb33a7882845e5a29cb488ac76b0e60e000000001976a914bd492b67f90cb85918494767ebb23102c4f06b7088ac67000000")
+	tx := mustParseTx()
 
 	b.Run("clone", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
@@ -38,7 +97,7 @@ func BenchmarkClone(b *testing.B) {
 
 // BenchmarkSize benchmarks the zero-allocation Size method vs len(Bytes()).
 func BenchmarkSize(b *testing.B) {
-	tx, _ := bt.NewTxFromString("0200000003a9bc457fdc6a54d99300fb137b23714d860c350a9d19ff0f571e694a419ff3a0010000006b48304502210086c83beb2b2663e4709a583d261d75be538aedcafa7766bd983e5c8db2f8b2fc02201a88b178624ab0ad1748b37c875f885930166237c88f5af78ee4e61d337f935f412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff0092bb9a47e27bf64fc98f557c530c04d9ac25e2f2a8b600e92a0b1ae7c89c20010000006b483045022100f06b3db1c0a11af348401f9cebe10ae2659d6e766a9dcd9e3a04690ba10a160f02203f7fbd7dfcfc70863aface1a306fcc91bbadf6bc884c21a55ef0d32bd6b088c8412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff9d0d4554fa692420a0830ca614b6c60f1bf8eaaa21afca4aa8c99fb052d9f398000000006b483045022100d920f2290548e92a6235f8b2513b7f693a64a0d3fa699f81a034f4b4608ff82f0220767d7d98025aff3c7bd5f2a66aab6a824f5990392e6489aae1e1ae3472d8dffb412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff02807c814a000000001976a9143a6bf34ebfcf30e8541bbb33a7882845e5a29cb488ac76b0e60e000000001976a914bd492b67f90cb85918494767ebb23102c4f06b7088ac67000000")
+	tx := mustParseTx()
 
 	b.Run("Size_arithmetic", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
@@ -57,70 +116,10 @@ func BenchmarkSize(b *testing.B) {
 
 // TestSize_MatchesBytes verifies the arithmetic Size() matches len(Bytes()) for various tx shapes.
 func TestSize_MatchesBytes(t *testing.T) {
-	tests := []struct {
-		name    string
-		buildTx func(t *testing.T) *bt.Tx
-	}{
-		{
-			name: "real tx with 3 inputs 2 outputs",
-			buildTx: func(t *testing.T) *bt.Tx {
-				tx, err := bt.NewTxFromString("0200000003a9bc457fdc6a54d99300fb137b23714d860c350a9d19ff0f571e694a419ff3a0010000006b48304502210086c83beb2b2663e4709a583d261d75be538aedcafa7766bd983e5c8db2f8b2fc02201a88b178624ab0ad1748b37c875f885930166237c88f5af78ee4e61d337f935f412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff0092bb9a47e27bf64fc98f557c530c04d9ac25e2f2a8b600e92a0b1ae7c89c20010000006b483045022100f06b3db1c0a11af348401f9cebe10ae2659d6e766a9dcd9e3a04690ba10a160f02203f7fbd7dfcfc70863aface1a306fcc91bbadf6bc884c21a55ef0d32bd6b088c8412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff9d0d4554fa692420a0830ca614b6c60f1bf8eaaa21afca4aa8c99fb052d9f398000000006b483045022100d920f2290548e92a6235f8b2513b7f693a64a0d3fa699f81a034f4b4608ff82f0220767d7d98025aff3c7bd5f2a66aab6a824f5990392e6489aae1e1ae3472d8dffb412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff02807c814a000000001976a9143a6bf34ebfcf30e8541bbb33a7882845e5a29cb488ac76b0e60e000000001976a914bd492b67f90cb85918494767ebb23102c4f06b7088ac67000000")
-				require.NoError(t, err)
-				return tx
-			},
-		},
-		{
-			name: "coinbase tx",
-			buildTx: func(t *testing.T) *bt.Tx {
-				tx, err := bt.NewTxFromString("01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0704ffff001d0104ffffffff0100f2052a0100000043410496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858eeac00000000")
-				require.NoError(t, err)
-				return tx
-			},
-		},
-		{
-			name: "single input single output",
-			buildTx: func(t *testing.T) *bt.Tx {
-				tx := bt.NewTx()
-				require.NoError(t, tx.From("b7b0650a7c3a1bd4f7571b4c1e38f05171b565b8e28b2e337031ee31e9fa8eb6", 0, "76a914167c3e911a14a92760b81334d01045da61e9681888ac", 100000))
-				tx.AddOutput(&bt.Output{
-					Satoshis:      99000,
-					LockingScript: bscript.NewFromBytes([]byte{0x76, 0xa9, 0x14}),
-				})
-				return tx
-			},
-		},
-		{
-			name: "large script output",
-			buildTx: func(t *testing.T) *bt.Tx {
-				tx := bt.NewTx()
-				require.NoError(t, tx.From("b7b0650a7c3a1bd4f7571b4c1e38f05171b565b8e28b2e337031ee31e9fa8eb6", 0, "76a914167c3e911a14a92760b81334d01045da61e9681888ac", 100000))
-				bigScript := make([]byte, 100000)
-				_, _ = rand.Read(bigScript)
-				tx.AddOutput(&bt.Output{
-					Satoshis:      1,
-					LockingScript: bscript.NewFromBytes(bigScript),
-				})
-				return tx
-			},
-		},
-		{
-			name: "empty unlocking scripts",
-			buildTx: func(t *testing.T) *bt.Tx {
-				tx := bt.NewTx()
-				tx.AddOutput(&bt.Output{
-					Satoshis:      1000,
-					LockingScript: bscript.NewFromBytes([]byte{0x51}),
-				})
-				return tx
-			},
-		},
-	}
-
-	for _, tt := range tests {
+	for _, tt := range txShapeTests(t) {
 		t.Run(tt.name, func(t *testing.T) {
-			tx := tt.buildTx(t)
-			expected := len(tx.Bytes())
-			got := tx.Size()
+			expected := len(tt.tx.Bytes())
+			got := tt.tx.Size()
 			require.Equal(t, expected, got, "Size() = %d, len(Bytes()) = %d", got, expected)
 		})
 	}
@@ -128,81 +127,20 @@ func TestSize_MatchesBytes(t *testing.T) {
 
 // TestWriteTo_MatchesBytes verifies WriteTo produces identical output to Bytes() for various tx shapes.
 func TestWriteTo_MatchesBytes(t *testing.T) {
-	tests := []struct {
-		name    string
-		buildTx func(t *testing.T) *bt.Tx
-	}{
-		{
-			name: "real tx with 3 inputs 2 outputs",
-			buildTx: func(t *testing.T) *bt.Tx {
-				tx, err := bt.NewTxFromString("0200000003a9bc457fdc6a54d99300fb137b23714d860c350a9d19ff0f571e694a419ff3a0010000006b48304502210086c83beb2b2663e4709a583d261d75be538aedcafa7766bd983e5c8db2f8b2fc02201a88b178624ab0ad1748b37c875f885930166237c88f5af78ee4e61d337f935f412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff0092bb9a47e27bf64fc98f557c530c04d9ac25e2f2a8b600e92a0b1ae7c89c20010000006b483045022100f06b3db1c0a11af348401f9cebe10ae2659d6e766a9dcd9e3a04690ba10a160f02203f7fbd7dfcfc70863aface1a306fcc91bbadf6bc884c21a55ef0d32bd6b088c8412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff9d0d4554fa692420a0830ca614b6c60f1bf8eaaa21afca4aa8c99fb052d9f398000000006b483045022100d920f2290548e92a6235f8b2513b7f693a64a0d3fa699f81a034f4b4608ff82f0220767d7d98025aff3c7bd5f2a66aab6a824f5990392e6489aae1e1ae3472d8dffb412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff02807c814a000000001976a9143a6bf34ebfcf30e8541bbb33a7882845e5a29cb488ac76b0e60e000000001976a914bd492b67f90cb85918494767ebb23102c4f06b7088ac67000000")
-				require.NoError(t, err)
-				return tx
-			},
-		},
-		{
-			name: "coinbase tx",
-			buildTx: func(t *testing.T) *bt.Tx {
-				tx, err := bt.NewTxFromString("01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0704ffff001d0104ffffffff0100f2052a0100000043410496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858eeac00000000")
-				require.NoError(t, err)
-				return tx
-			},
-		},
-		{
-			name: "single input single output",
-			buildTx: func(t *testing.T) *bt.Tx {
-				tx := bt.NewTx()
-				require.NoError(t, tx.From("b7b0650a7c3a1bd4f7571b4c1e38f05171b565b8e28b2e337031ee31e9fa8eb6", 0, "76a914167c3e911a14a92760b81334d01045da61e9681888ac", 100000))
-				tx.AddOutput(&bt.Output{
-					Satoshis:      99000,
-					LockingScript: bscript.NewFromBytes([]byte{0x76, 0xa9, 0x14}),
-				})
-				return tx
-			},
-		},
-		{
-			name: "large script output",
-			buildTx: func(t *testing.T) *bt.Tx {
-				tx := bt.NewTx()
-				require.NoError(t, tx.From("b7b0650a7c3a1bd4f7571b4c1e38f05171b565b8e28b2e337031ee31e9fa8eb6", 0, "76a914167c3e911a14a92760b81334d01045da61e9681888ac", 100000))
-				bigScript := make([]byte, 100000)
-				_, _ = rand.Read(bigScript)
-				tx.AddOutput(&bt.Output{
-					Satoshis:      1,
-					LockingScript: bscript.NewFromBytes(bigScript),
-				})
-				return tx
-			},
-		},
-		{
-			name: "empty unlocking scripts",
-			buildTx: func(t *testing.T) *bt.Tx {
-				tx := bt.NewTx()
-				tx.AddOutput(&bt.Output{
-					Satoshis:      1000,
-					LockingScript: bscript.NewFromBytes([]byte{0x51}),
-				})
-				return tx
-			},
-		},
-	}
-
-	for _, tt := range tests {
+	for _, tt := range txShapeTests(t) {
 		t.Run(tt.name, func(t *testing.T) {
-			tx := tt.buildTx(t)
-
 			// Test standard WriteTo
-			expected := tx.Bytes()
+			expected := tt.tx.Bytes()
 			var buf bytes.Buffer
-			n, err := tx.WriteTo(&buf)
+			n, err := tt.tx.WriteTo(&buf)
 			require.NoError(t, err)
 			require.Equal(t, int64(len(expected)), n)
 			require.Equal(t, expected, buf.Bytes())
 
 			// Test SerializeTo matches SerializeBytes
-			expectedSerialized := tx.SerializeBytes()
+			expectedSerialized := tt.tx.SerializeBytes()
 			buf.Reset()
-			n, err = tx.SerializeTo(&buf)
+			n, err = tt.tx.SerializeTo(&buf)
 			require.NoError(t, err)
 			require.Equal(t, int64(len(expectedSerialized)), n)
 			require.Equal(t, expectedSerialized, buf.Bytes())
@@ -212,7 +150,7 @@ func TestWriteTo_MatchesBytes(t *testing.T) {
 
 // BenchmarkWriteTo benchmarks WriteTo vs Bytes() serialization.
 func BenchmarkWriteTo(b *testing.B) {
-	tx, _ := bt.NewTxFromString("0200000003a9bc457fdc6a54d99300fb137b23714d860c350a9d19ff0f571e694a419ff3a0010000006b48304502210086c83beb2b2663e4709a583d261d75be538aedcafa7766bd983e5c8db2f8b2fc02201a88b178624ab0ad1748b37c875f885930166237c88f5af78ee4e61d337f935f412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff0092bb9a47e27bf64fc98f557c530c04d9ac25e2f2a8b600e92a0b1ae7c89c20010000006b483045022100f06b3db1c0a11af348401f9cebe10ae2659d6e766a9dcd9e3a04690ba10a160f02203f7fbd7dfcfc70863aface1a306fcc91bbadf6bc884c21a55ef0d32bd6b088c8412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff9d0d4554fa692420a0830ca614b6c60f1bf8eaaa21afca4aa8c99fb052d9f398000000006b483045022100d920f2290548e92a6235f8b2513b7f693a64a0d3fa699f81a034f4b4608ff82f0220767d7d98025aff3c7bd5f2a66aab6a824f5990392e6489aae1e1ae3472d8dffb412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff02807c814a000000001976a9143a6bf34ebfcf30e8541bbb33a7882845e5a29cb488ac76b0e60e000000001976a914bd492b67f90cb85918494767ebb23102c4f06b7088ac67000000")
+	tx := mustParseTx()
 
 	b.Run("WriteTo", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
@@ -229,77 +167,17 @@ func BenchmarkWriteTo(b *testing.B) {
 
 // TestAppendBytes_MatchesBytes verifies AppendBytes produces identical output to Bytes().
 func TestAppendBytes_MatchesBytes(t *testing.T) {
-	tests := []struct {
-		name    string
-		buildTx func(t *testing.T) *bt.Tx
-	}{
-		{
-			name: "real tx with 3 inputs 2 outputs",
-			buildTx: func(t *testing.T) *bt.Tx {
-				tx, err := bt.NewTxFromString("0200000003a9bc457fdc6a54d99300fb137b23714d860c350a9d19ff0f571e694a419ff3a0010000006b48304502210086c83beb2b2663e4709a583d261d75be538aedcafa7766bd983e5c8db2f8b2fc02201a88b178624ab0ad1748b37c875f885930166237c88f5af78ee4e61d337f935f412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff0092bb9a47e27bf64fc98f557c530c04d9ac25e2f2a8b600e92a0b1ae7c89c20010000006b483045022100f06b3db1c0a11af348401f9cebe10ae2659d6e766a9dcd9e3a04690ba10a160f02203f7fbd7dfcfc70863aface1a306fcc91bbadf6bc884c21a55ef0d32bd6b088c8412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff9d0d4554fa692420a0830ca614b6c60f1bf8eaaa21afca4aa8c99fb052d9f398000000006b483045022100d920f2290548e92a6235f8b2513b7f693a64a0d3fa699f81a034f4b4608ff82f0220767d7d98025aff3c7bd5f2a66aab6a824f5990392e6489aae1e1ae3472d8dffb412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff02807c814a000000001976a9143a6bf34ebfcf30e8541bbb33a7882845e5a29cb488ac76b0e60e000000001976a914bd492b67f90cb85918494767ebb23102c4f06b7088ac67000000")
-				require.NoError(t, err)
-				return tx
-			},
-		},
-		{
-			name: "coinbase tx",
-			buildTx: func(t *testing.T) *bt.Tx {
-				tx, err := bt.NewTxFromString("01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0704ffff001d0104ffffffff0100f2052a0100000043410496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858eeac00000000")
-				require.NoError(t, err)
-				return tx
-			},
-		},
-		{
-			name: "single input single output",
-			buildTx: func(t *testing.T) *bt.Tx {
-				tx := bt.NewTx()
-				require.NoError(t, tx.From("b7b0650a7c3a1bd4f7571b4c1e38f05171b565b8e28b2e337031ee31e9fa8eb6", 0, "76a914167c3e911a14a92760b81334d01045da61e9681888ac", 100000))
-				tx.AddOutput(&bt.Output{
-					Satoshis:      99000,
-					LockingScript: bscript.NewFromBytes([]byte{0x76, 0xa9, 0x14}),
-				})
-				return tx
-			},
-		},
-		{
-			name: "large script output",
-			buildTx: func(t *testing.T) *bt.Tx {
-				tx := bt.NewTx()
-				require.NoError(t, tx.From("b7b0650a7c3a1bd4f7571b4c1e38f05171b565b8e28b2e337031ee31e9fa8eb6", 0, "76a914167c3e911a14a92760b81334d01045da61e9681888ac", 100000))
-				bigScript := make([]byte, 100000)
-				_, _ = rand.Read(bigScript)
-				tx.AddOutput(&bt.Output{
-					Satoshis:      1,
-					LockingScript: bscript.NewFromBytes(bigScript),
-				})
-				return tx
-			},
-		},
-		{
-			name: "empty unlocking scripts",
-			buildTx: func(t *testing.T) *bt.Tx {
-				tx := bt.NewTx()
-				tx.AddOutput(&bt.Output{
-					Satoshis:      1000,
-					LockingScript: bscript.NewFromBytes([]byte{0x51}),
-				})
-				return tx
-			},
-		},
-	}
-
-	for _, tt := range tests {
+	for _, tt := range txShapeTests(t) {
 		t.Run(tt.name, func(t *testing.T) {
-			tx := tt.buildTx(t)
-			expected := tx.Bytes()
+			expected := tt.tx.Bytes()
 
 			// AppendBytes to nil should produce same bytes
-			got := tx.AppendBytes(nil)
+			got := tt.tx.AppendBytes(nil)
 			require.Equal(t, expected, got)
 
 			// AppendBytes to pre-allocated buffer should produce same bytes
-			buf := make([]byte, 0, tx.Size())
-			got = tx.AppendBytes(buf)
+			buf := make([]byte, 0, tt.tx.Size())
+			got = tt.tx.AppendBytes(buf)
 			require.Equal(t, expected, got)
 		})
 	}
@@ -307,8 +185,7 @@ func TestAppendBytes_MatchesBytes(t *testing.T) {
 
 // TestAppendBytes_ZeroAllocs verifies AppendBytes does not allocate when given a sufficiently sized buffer.
 func TestAppendBytes_ZeroAllocs(t *testing.T) {
-	tx, err := bt.NewTxFromString("0200000003a9bc457fdc6a54d99300fb137b23714d860c350a9d19ff0f571e694a419ff3a0010000006b48304502210086c83beb2b2663e4709a583d261d75be538aedcafa7766bd983e5c8db2f8b2fc02201a88b178624ab0ad1748b37c875f885930166237c88f5af78ee4e61d337f935f412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff0092bb9a47e27bf64fc98f557c530c04d9ac25e2f2a8b600e92a0b1ae7c89c20010000006b483045022100f06b3db1c0a11af348401f9cebe10ae2659d6e766a9dcd9e3a04690ba10a160f02203f7fbd7dfcfc70863aface1a306fcc91bbadf6bc884c21a55ef0d32bd6b088c8412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff9d0d4554fa692420a0830ca614b6c60f1bf8eaaa21afca4aa8c99fb052d9f398000000006b483045022100d920f2290548e92a6235f8b2513b7f693a64a0d3fa699f81a034f4b4608ff82f0220767d7d98025aff3c7bd5f2a66aab6a824f5990392e6489aae1e1ae3472d8dffb412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff02807c814a000000001976a9143a6bf34ebfcf30e8541bbb33a7882845e5a29cb488ac76b0e60e000000001976a914bd492b67f90cb85918494767ebb23102c4f06b7088ac67000000")
-	require.NoError(t, err)
+	tx := mustParseTx()
 
 	buf := make([]byte, 0, tx.Size())
 	allocs := testing.AllocsPerRun(100, func() {
@@ -319,8 +196,7 @@ func TestAppendBytes_ZeroAllocs(t *testing.T) {
 
 // TestBytes_ExactAlloc verifies that Bytes() allocates exactly the right size (no wasted capacity).
 func TestBytes_ExactAlloc(t *testing.T) {
-	tx, err := bt.NewTxFromString("0200000003a9bc457fdc6a54d99300fb137b23714d860c350a9d19ff0f571e694a419ff3a0010000006b48304502210086c83beb2b2663e4709a583d261d75be538aedcafa7766bd983e5c8db2f8b2fc02201a88b178624ab0ad1748b37c875f885930166237c88f5af78ee4e61d337f935f412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff0092bb9a47e27bf64fc98f557c530c04d9ac25e2f2a8b600e92a0b1ae7c89c20010000006b483045022100f06b3db1c0a11af348401f9cebe10ae2659d6e766a9dcd9e3a04690ba10a160f02203f7fbd7dfcfc70863aface1a306fcc91bbadf6bc884c21a55ef0d32bd6b088c8412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff9d0d4554fa692420a0830ca614b6c60f1bf8eaaa21afca4aa8c99fb052d9f398000000006b483045022100d920f2290548e92a6235f8b2513b7f693a64a0d3fa699f81a034f4b4608ff82f0220767d7d98025aff3c7bd5f2a66aab6a824f5990392e6489aae1e1ae3472d8dffb412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff02807c814a000000001976a9143a6bf34ebfcf30e8541bbb33a7882845e5a29cb488ac76b0e60e000000001976a914bd492b67f90cb85918494767ebb23102c4f06b7088ac67000000")
-	require.NoError(t, err)
+	tx := mustParseTx()
 
 	b := tx.Bytes()
 	require.Equal(t, len(b), cap(b), "Bytes() should allocate exactly the right capacity, got len=%d cap=%d", len(b), cap(b))
@@ -328,7 +204,7 @@ func TestBytes_ExactAlloc(t *testing.T) {
 
 // BenchmarkAppendBytes benchmarks the zero-alloc AppendBytes method.
 func BenchmarkAppendBytes(b *testing.B) {
-	tx, _ := bt.NewTxFromString("0200000003a9bc457fdc6a54d99300fb137b23714d860c350a9d19ff0f571e694a419ff3a0010000006b48304502210086c83beb2b2663e4709a583d261d75be538aedcafa7766bd983e5c8db2f8b2fc02201a88b178624ab0ad1748b37c875f885930166237c88f5af78ee4e61d337f935f412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff0092bb9a47e27bf64fc98f557c530c04d9ac25e2f2a8b600e92a0b1ae7c89c20010000006b483045022100f06b3db1c0a11af348401f9cebe10ae2659d6e766a9dcd9e3a04690ba10a160f02203f7fbd7dfcfc70863aface1a306fcc91bbadf6bc884c21a55ef0d32bd6b088c8412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff9d0d4554fa692420a0830ca614b6c60f1bf8eaaa21afca4aa8c99fb052d9f398000000006b483045022100d920f2290548e92a6235f8b2513b7f693a64a0d3fa699f81a034f4b4608ff82f0220767d7d98025aff3c7bd5f2a66aab6a824f5990392e6489aae1e1ae3472d8dffb412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff02807c814a000000001976a9143a6bf34ebfcf30e8541bbb33a7882845e5a29cb488ac76b0e60e000000001976a914bd492b67f90cb85918494767ebb23102c4f06b7088ac67000000")
+	tx := mustParseTx()
 
 	buf := make([]byte, 0, tx.Size())
 	b.Run("AppendBytes_reuse", func(b *testing.B) {
@@ -346,7 +222,7 @@ func BenchmarkAppendBytes(b *testing.B) {
 
 // BenchmarkShallowClone benchmarks the ShallowClone method of a transaction.
 func BenchmarkShallowClone(b *testing.B) {
-	tx, _ := bt.NewTxFromString("0200000003a9bc457fdc6a54d99300fb137b23714d860c350a9d19ff0f571e694a419ff3a0010000006b48304502210086c83beb2b2663e4709a583d261d75be538aedcafa7766bd983e5c8db2f8b2fc02201a88b178624ab0ad1748b37c875f885930166237c88f5af78ee4e61d337f935f412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff0092bb9a47e27bf64fc98f557c530c04d9ac25e2f2a8b600e92a0b1ae7c89c20010000006b483045022100f06b3db1c0a11af348401f9cebe10ae2659d6e766a9dcd9e3a04690ba10a160f02203f7fbd7dfcfc70863aface1a306fcc91bbadf6bc884c21a55ef0d32bd6b088c8412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff9d0d4554fa692420a0830ca614b6c60f1bf8eaaa21afca4aa8c99fb052d9f398000000006b483045022100d920f2290548e92a6235f8b2513b7f693a64a0d3fa699f81a034f4b4608ff82f0220767d7d98025aff3c7bd5f2a66aab6a824f5990392e6489aae1e1ae3472d8dffb412103e8be830d98bb3b007a0343ee5c36daa48796ae8bb57946b1e87378ad6e8a090dfeffffff02807c814a000000001976a9143a6bf34ebfcf30e8541bbb33a7882845e5a29cb488ac76b0e60e000000001976a914bd492b67f90cb85918494767ebb23102c4f06b7088ac67000000")
+	tx := mustParseTx()
 
 	b.Run("clone", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {

--- a/tx_input.go
+++ b/tx_input.go
@@ -3,7 +3,6 @@ package bt
 import (
 	"bytes"
 	"context"
-	"encoding/binary"
 	"fmt"
 
 	crypto "github.com/bsv-blockchain/go-sdk/primitives/hash"
@@ -177,11 +176,12 @@ func (tx *Tx) InputCount() int {
 func (tx *Tx) PreviousOutHash() []byte {
 	buf := make([]byte, 0, len(tx.Inputs)*36)
 
-	oi := make([]byte, 4)
 	for _, in := range tx.Inputs {
 		buf = append(buf, in.previousTxIDHash[:]...)
-		binary.LittleEndian.PutUint32(oi, in.PreviousTxOutIndex)
-		buf = append(buf, oi...)
+		buf = append(buf,
+			byte(in.PreviousTxOutIndex), byte(in.PreviousTxOutIndex>>8),
+			byte(in.PreviousTxOutIndex>>16), byte(in.PreviousTxOutIndex>>24),
+		)
 	}
 
 	return crypto.Sha256d(buf)
@@ -191,10 +191,11 @@ func (tx *Tx) PreviousOutHash() []byte {
 func (tx *Tx) SequenceHash() []byte {
 	buf := make([]byte, 0, len(tx.Inputs)*4)
 
-	oi := make([]byte, 4)
 	for _, in := range tx.Inputs {
-		binary.LittleEndian.PutUint32(oi, in.SequenceNumber)
-		buf = append(buf, oi...)
+		buf = append(buf,
+			byte(in.SequenceNumber), byte(in.SequenceNumber>>8),
+			byte(in.SequenceNumber>>16), byte(in.SequenceNumber>>24),
+		)
 	}
 
 	return crypto.Sha256d(buf)

--- a/varint.go
+++ b/varint.go
@@ -65,6 +65,22 @@ func (v VarInt) Bytes() []byte {
 	return b
 }
 
+// AppendTo appends the VarInt encoding to dst and returns the extended slice.
+// It never allocates when dst has sufficient capacity.
+func (v VarInt) AppendTo(dst []byte) []byte {
+	if v < 0xfd {
+		return append(dst, byte(v))
+	}
+	if v < 0x10000 {
+		return append(dst, 0xfd, byte(v), byte(v>>8))
+	}
+	if v < 0x100000000 {
+		return append(dst, 0xfe, byte(v), byte(v>>8), byte(v>>16), byte(v>>24))
+	}
+	return append(dst, 0xff, byte(v), byte(v>>8), byte(v>>16), byte(v>>24),
+		byte(v>>32), byte(v>>40), byte(v>>48), byte(v>>56))
+}
+
 // WriteTo writes the VarInt to w without allocating.
 func (v VarInt) WriteTo(w io.Writer) (int64, error) {
 	var buf [9]byte

--- a/varint_test.go
+++ b/varint_test.go
@@ -129,3 +129,48 @@ func TestVarInt_Size(t *testing.T) {
 		})
 	}
 }
+
+func TestVarInt_AppendTo(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input uint64
+	}{
+		{"zero", 0},
+		{"one byte max", 252},
+		{"three byte min", 253},
+		{"three byte max", 65535},
+		{"five byte min", 65536},
+		{"five byte max", 4294967295},
+		{"nine byte min", 4294967296},
+		{"nine byte max", 18446744073709551615},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := bt.VarInt(tt.input)
+			expected := v.Bytes()
+
+			// AppendTo on nil should produce same bytes
+			got := v.AppendTo(nil)
+			assert.Equal(t, expected, got)
+
+			// AppendTo on existing prefix should preserve prefix
+			prefix := []byte{0xDE, 0xAD}
+			got = v.AppendTo(prefix)
+			assert.Equal(t, prefix, got[:2])
+			assert.Equal(t, expected, got[2:])
+		})
+	}
+}
+
+func TestVarInt_AppendTo_ZeroAllocs(t *testing.T) {
+	v := bt.VarInt(1000)
+	buf := make([]byte, 0, 16)
+
+	allocs := testing.AllocsPerRun(100, func() {
+		buf = v.AppendTo(buf[:0])
+	})
+	assert.Equal(t, float64(0), allocs, "AppendTo should not allocate when buffer has capacity")
+}

--- a/varint_test.go
+++ b/varint_test.go
@@ -172,5 +172,5 @@ func TestVarInt_AppendTo_ZeroAllocs(t *testing.T) {
 	allocs := testing.AllocsPerRun(100, func() {
 		buf = v.AppendTo(buf[:0])
 	})
-	assert.Equal(t, float64(0), allocs, "AppendTo should not allocate when buffer has capacity")
+	assert.InDelta(t, 0, allocs, 0, "AppendTo should not allocate when buffer has capacity")
 }


### PR DESCRIPTION
## Summary

Reduce memory allocations across the two hottest paths in go-bt: transaction serialization and signature hashing.

- **`toBytesHelper`**: pre-compute exact buffer size via `tx.Size()` instead of fixed 1024-byte capacity; add `VarInt.AppendTo`, `Input.appendTo`, `Output.appendTo` that append without allocating; add `Tx.AppendBytes(dst)` for callers who reuse a buffer
- **`CalcInputPreimage`**: add `SigHashCache` + `CalcInputPreimageWithCache()` to pre-compute `PreviousOutHash`/`SequenceHash`/`OutputsHash` once across all inputs (eliminates O(N²) → O(N)); eliminate all temp `make([]byte, 4/8)` slices; use `hash[:]` instead of `CloneBytes()`; use `ShallowClone` instead of `Clone` in legacy path; pre-size `OutputsHash` buffer

## Benchmark results

**Serialization** (3-input, 2-output tx):

| Method | Before | After | Change |
|--------|--------|-------|--------|
| `Bytes()` | 189 ns, 1024 B, 1 alloc | 109 ns, 576 B, 1 alloc | 42% faster, 44% less memory |
| `AppendBytes()` (reuse buf) | n/a | 29 ns, 0 B, 0 allocs | **zero-alloc path** |

**Sighash** (signing all N inputs of a tx):

| N inputs | Uncached | Cached | Speedup |
|----------|----------|--------|---------|
| 5 | 2.2 µs, 2.4 KB, 25 allocs | 611 ns, 1.3 KB, 10 allocs | 3.5x faster |
| 20 | 15 µs, 22 KB, 120 allocs | 1.5 µs, 4.8 KB, 26 allocs | 10x faster |
| 100 | 242 µs, 480 KB, 600 allocs | 6.6 µs, 24 KB, 106 allocs | **37x faster, 95% less memory** |

## New public API

- `VarInt.AppendTo(dst []byte) []byte` — append varint encoding without allocating
- `Tx.AppendBytes(dst []byte) []byte` — append serialized tx to caller-provided buffer (zero-alloc when pre-sized via `tx.Size()`)
- `SigHashCache` struct — holds pre-computed intermediate hashes for sighash
- `Tx.NewSigHashCache() *SigHashCache` — compute the cache
- `Tx.CalcInputPreimageWithCache(inputNumber, sigHashFlag, cache)` — sighash with cache

All existing public APIs are unchanged and backwards compatible.

## Files changed

| File | What changed |
|------|-------------|
| `varint.go` | Added `AppendTo` |
| `input.go` | Added `appendTo`, `appendExtendedTo` (unexported, use `hash[:]` not `CloneBytes`) |
| `output.go` | Added `appendTo` (unexported); simplified `BytesForSigHash` |
| `tx.go` | Refactored `toBytesHelper` to pre-size via `Size()`; added `AppendBytes`, `appendBytesHelper` |
| `tx_input.go` | Eliminated temp slices in `PreviousOutHash`/`SequenceHash` |
| `signature_hash.go` | Added `SigHashCache`, `CalcInputPreimageWithCache`, `calcInputPreimage`; eliminated all temp `make` slices; `ShallowClone` in legacy path; pre-sized `OutputsHash` |
| `varint_test.go` | Tests for `AppendTo` correctness and zero-alloc |
| `tx_benchmark_test.go` | Tests for `AppendBytes` correctness, exact-alloc, and zero-alloc; benchmarks |
| `signature_hash_benchmark_test.go` | Benchmarks for cached vs uncached sighash; correctness test for cache |

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] Known-good hex vectors for `CalcInputPreimage`, `CalcInputPreimageLegacy`, `CalcInputSignatureHash` still match
- [x] `VarInt.AppendTo` produces identical bytes to `VarInt.Bytes()` across all size categories
- [x] `Tx.AppendBytes` produces identical bytes to `Tx.Bytes()` for various tx shapes
- [x] `Tx.Bytes()` allocates exactly `len` == `cap` (no wasted capacity)
- [x] `AppendBytes` with pre-sized buffer verified at 0 allocs via `testing.AllocsPerRun`
- [x] `CalcInputPreimageWithCache` produces identical preimages to uncached path for all inputs
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)