### PR TITLE
[Sync] Update project files from source repository (0f07170)

### DIFF
--- a/.github/actions/warm-cache/action.yml
+++ b/.github/actions/warm-cache/action.yml
@@ -267,7 +267,7 @@ runs:
     # ────────────────────────────────────────────────────────────────────────────
     - name: 📥 Full checkout for module download (module cache miss)
       if: steps.setup-go.outputs.module-cache-hit != 'true'
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
 
@@ -306,7 +306,7 @@ runs:
     # ────────────────────────────────────────────────────────────────────────────
     - name: 📥 Full checkout for build warming (module hit, build miss)
       if: steps.setup-go.outputs.module-cache-hit == 'true' && steps.setup-go.outputs.build-cache-hit != 'true'
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,7 +49,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e0647621c2984b5ed2f768cb892365bf2a616ad1 # v4.37.2
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -60,7 +60,7 @@ jobs:
       # Autobuild attempts to build any compiled languages (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@e0647621c2984b5ed2f768cb892365bf2a616ad1 # v4.37.2
+        uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -70,4 +70,4 @@ jobs:
       #    uses a compiled language
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e0647621c2984b5ed2f768cb892365bf2a616ad1 # v4.37.2
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -77,6 +77,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable the upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@e0647621c2984b5ed2f768cb892365bf2a616ad1 # v4.37.2
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@
        &nbsp;&nbsp;&nbsp;&nbsp; <code>Quality</code> &nbsp;&nbsp;
     </td>
     <td align="left">
-       <a href="https://goreportcard.com/report/github.com/bsv-blockchain/go-bt/v2"><img src="https://goreportcard.com/badge/github.com/bsv-blockchain/go-bt/v2?style=flat-square" alt="Go Report"></a>
        <a href="https://codecov.io/gh/bsv-blockchain/go-bt"><img src="https://codecov.io/gh/bsv-blockchain/go-bt/branch/master/graph/badge.svg?style=flat-square" alt="Coverage"></a>
     </td>
   </tr>

--- a/bscript/address_test.go
+++ b/bscript/address_test.go
@@ -109,7 +109,8 @@ func TestBase58EncodeMissingChecksum(t *testing.T) {
 	input, err := hex.DecodeString("0488b21e000000000000000000362f7a9030543db8751401c387d6a71e870f1895b3a62569d455e8ee5f5f5e5f03036624c6df96984db6b4e625b6707c017eb0e0d137cd13a0c989bfa77a4473fd")
 	require.NoError(t, err)
 
-	assert.Equal(t,
+	assert.Equal(
+		t,
 		"xpub661MyMwAqRbcF5ivRisXcZTEoy7d9DfLF6fLqpu5GWMfeUyGHuWJHVp5uexDqXTWoySh8pNx3ELW7qymwPNg3UEYHjwh1tpdm3P9J2j4g32",
 		bscript.Base58EncodeMissingChecksum(input),
 	)

--- a/bscript/interpreter/op_code_parser.go
+++ b/bscript/interpreter/op_code_parser.go
@@ -353,7 +353,8 @@ func (o *ParsedOpcode) bytes() ([]byte, error) {
 	retbytes = append(retbytes, o.Data...)
 
 	if len(retbytes) != nbytes {
-		return nil, errs.NewError(errs.ErrInternal,
+		return nil, errs.NewError(
+			errs.ErrInternal,
 			"internal consistency error - parsed opcode %s has data length %d when %d was expected",
 			o.Name(), len(retbytes), nbytes,
 		)

--- a/bscript/interpreter/thread.go
+++ b/bscript/interpreter/thread.go
@@ -649,7 +649,8 @@ func (t *thread) checkSignatureEncoding(sig []byte) error {
 	// The signature must indicate the correct amount of data for all elements
 	// related to R and S.
 	if int(sig[dataLenOffset]) != sigLen-2 {
-		return errs.NewError(errs.ErrSigInvalidDataLen,
+		return errs.NewError(
+			errs.ErrSigInvalidDataLen,
 			"malformed signature: bad length: %d != %d",
 			sig[dataLenOffset], sigLen-2,
 		)

--- a/bscript/script_test.go
+++ b/bscript/script_test.go
@@ -27,7 +27,8 @@ func TestNewP2PKHFromPubKeyStr(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.NotNil(t, scriptP2PKH)
-	assert.Equal(t,
+	assert.Equal(
+		t,
 		"76a9144d5d1920331b71735a97a606d9734aed83cb3dfa88ac",
 		hex.EncodeToString(*scriptP2PKH),
 	)
@@ -44,7 +45,8 @@ func TestNewP2PKHFromPubKey(t *testing.T) {
 	scriptP2PKH, err := bscript.NewP2PKHFromPubKeyEC(pubkey)
 	require.NoError(t, err)
 	assert.NotNil(t, scriptP2PKH)
-	assert.Equal(t,
+	assert.Equal(
+		t,
 		"76a9144d5d1920331b71735a97a606d9734aed83cb3dfa88ac",
 		hex.EncodeToString(*scriptP2PKH),
 	)
@@ -88,7 +90,8 @@ func TestNewFromHexString(t *testing.T) {
 	s, err := bscript.NewFromHexString("76a914e2a623699e81b291c0327f408fea765d534baa2a88ac")
 	require.NoError(t, err)
 	assert.NotNil(t, s)
-	assert.Equal(t,
+	assert.Equal(
+		t,
 		"76a914e2a623699e81b291c0327f408fea765d534baa2a88ac",
 		hex.EncodeToString(*s),
 	)
@@ -130,7 +133,8 @@ func TestNewFromASM(t *testing.T) {
 	s, err := bscript.NewFromASM("OP_DUP OP_HASH160 e2a623699e81b291c0327f408fea765d534baa2a OP_EQUALVERIFY OP_CHECKSIG")
 	require.NoError(t, err)
 	assert.NotNil(t, s)
-	assert.Equal(t,
+	assert.Equal(
+		t,
 		"76a914e2a623699e81b291c0327f408fea765d534baa2a88ac",
 		hex.EncodeToString(*s),
 	)

--- a/byte_manipulation_test.go
+++ b/byte_manipulation_test.go
@@ -26,7 +26,8 @@ func TestReverseBytes(t *testing.T) {
 
 		h := bt.ReverseBytes(crypto.Sha256d(b))
 
-		assert.Equal(t,
+		assert.Equal(
+			t,
 			"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b",
 			hex.EncodeToString(h),
 		)
@@ -38,7 +39,8 @@ func TestReverseBytes(t *testing.T) {
 
 		h := bt.ReverseBytes(crypto.Sha256d(b[0:80]))
 
-		assert.Equal(t,
+		assert.Equal(
+			t,
 			"000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
 			hex.EncodeToString(h),
 		)

--- a/input.go
+++ b/input.go
@@ -352,7 +352,8 @@ func (i *Input) appendTo(h []byte, clearLockingScript bool) []byte {
 		h = append(h, i.previousTxIDHash[:]...)
 	}
 
-	h = append(h,
+	h = append(
+		h,
 		byte(i.PreviousTxOutIndex),
 		byte(i.PreviousTxOutIndex>>8),
 		byte(i.PreviousTxOutIndex>>16),
@@ -368,7 +369,8 @@ func (i *Input) appendTo(h []byte, clearLockingScript bool) []byte {
 		h = append(h, *i.UnlockingScript...)
 	}
 
-	return append(h,
+	return append(
+		h,
 		byte(i.SequenceNumber),
 		byte(i.SequenceNumber>>8),
 		byte(i.SequenceNumber>>16),
@@ -380,7 +382,8 @@ func (i *Input) appendTo(h []byte, clearLockingScript bool) []byte {
 func (i *Input) appendExtendedTo(h []byte, clearLockingScript bool) []byte {
 	h = i.appendTo(h, clearLockingScript)
 
-	h = append(h,
+	h = append(
+		h,
 		byte(i.PreviousTxSatoshis),
 		byte(i.PreviousTxSatoshis>>8),
 		byte(i.PreviousTxSatoshis>>16),

--- a/input_test.go
+++ b/input_test.go
@@ -189,7 +189,8 @@ func TestInput_String(t *testing.T) {
 		assert.NotNil(t, i)
 		assert.Equal(t, int64(148), s)
 
-		assert.Equal(t,
+		assert.Equal(
+			t,
 			"prevTxHash:   6fc75f30a085f3313265b92c818082f9768c13b8a1a107b484023ecf63c86e4c\nprevOutIndex: 1\nscriptLen:    107\nscript:       483045022100f01c1a1679c9437398d691c8497f278fa2d615efc05115688bf2c3335b45c88602201b54437e54fb53bc50545de44ea8c64e9e583952771fcc663c8687dc2638f7854121037e87bbd3b680748a74372640628a8f32d3a841ceeef6f75626ab030c1a04824f\nsequence:     ffffffff\n",
 			i.String(),
 		)

--- a/output.go
+++ b/output.go
@@ -117,7 +117,8 @@ func (o *Output) Size() int {
 
 // appendTo appends the serialized output to h without allocating.
 func (o *Output) appendTo(h []byte) []byte {
-	h = append(h,
+	h = append(
+		h,
 		byte(o.Satoshis),
 		byte(o.Satoshis>>8),
 		byte(o.Satoshis>>16),

--- a/signature_hash.go
+++ b/signature_hash.go
@@ -159,7 +159,8 @@ func (tx *Tx) calcInputPreimage(in *Input, sigHashFlag sighash.Flag,
 	buf := make([]byte, 0, bufSize)
 
 	// Version
-	buf = append(buf,
+	buf = append(
+		buf,
 		byte(tx.Version), byte(tx.Version>>8),
 		byte(tx.Version>>16), byte(tx.Version>>24),
 	)
@@ -178,7 +179,8 @@ func (tx *Tx) calcInputPreimage(in *Input, sigHashFlag sighash.Flag,
 
 	// outpoint (32-byte hash + 4-byte little endian)
 	buf = append(buf, in.previousTxIDHash[:]...)
-	buf = append(buf,
+	buf = append(
+		buf,
 		byte(in.PreviousTxOutIndex), byte(in.PreviousTxOutIndex>>8),
 		byte(in.PreviousTxOutIndex>>16), byte(in.PreviousTxOutIndex>>24),
 	)
@@ -188,7 +190,8 @@ func (tx *Tx) calcInputPreimage(in *Input, sigHashFlag sighash.Flag,
 	buf = append(buf, *in.PreviousTxScript...)
 
 	// value of the output spent by this input (8-byte little endian)
-	buf = append(buf,
+	buf = append(
+		buf,
 		byte(in.PreviousTxSatoshis), byte(in.PreviousTxSatoshis>>8),
 		byte(in.PreviousTxSatoshis>>16), byte(in.PreviousTxSatoshis>>24),
 		byte(in.PreviousTxSatoshis>>32), byte(in.PreviousTxSatoshis>>40),
@@ -196,7 +199,8 @@ func (tx *Tx) calcInputPreimage(in *Input, sigHashFlag sighash.Flag,
 	)
 
 	// nSequence of the input
-	buf = append(buf,
+	buf = append(
+		buf,
 		byte(in.SequenceNumber), byte(in.SequenceNumber>>8),
 		byte(in.SequenceNumber>>16), byte(in.SequenceNumber>>24),
 	)
@@ -209,14 +213,16 @@ func (tx *Tx) calcInputPreimage(in *Input, sigHashFlag sighash.Flag,
 	}
 
 	// LockTime
-	buf = append(buf,
+	buf = append(
+		buf,
 		byte(tx.LockTime), byte(tx.LockTime>>8),
 		byte(tx.LockTime>>16), byte(tx.LockTime>>24),
 	)
 
 	// sighashType
 	shf := uint32(sigHashFlag)
-	buf = append(buf,
+	buf = append(
+		buf,
 		byte(shf), byte(shf>>8),
 		byte(shf>>16), byte(shf>>24),
 	)
@@ -304,7 +310,8 @@ func (tx *Tx) CalcInputPreimageLegacy(inputNumber uint32, shf sighash.Flag) ([]b
 	buf := make([]byte, 0, txCopy.Size()+8)
 
 	// Version
-	buf = append(buf,
+	buf = append(
+		buf,
 		byte(tx.Version), byte(tx.Version>>8),
 		byte(tx.Version>>16), byte(tx.Version>>24),
 	)
@@ -315,7 +322,8 @@ func (tx *Tx) CalcInputPreimageLegacy(inputNumber uint32, shf sighash.Flag) ([]b
 			buf = append(buf, in.previousTxIDHash[:]...)
 		}
 
-		buf = append(buf,
+		buf = append(
+			buf,
 			byte(in.PreviousTxOutIndex), byte(in.PreviousTxOutIndex>>8),
 			byte(in.PreviousTxOutIndex>>16), byte(in.PreviousTxOutIndex>>24),
 		)
@@ -323,7 +331,8 @@ func (tx *Tx) CalcInputPreimageLegacy(inputNumber uint32, shf sighash.Flag) ([]b
 		buf = VarInt(uint64(len(*in.PreviousTxScript))).AppendTo(buf)
 		buf = append(buf, *in.PreviousTxScript...)
 
-		buf = append(buf,
+		buf = append(
+			buf,
 			byte(in.SequenceNumber), byte(in.SequenceNumber>>8),
 			byte(in.SequenceNumber>>16), byte(in.SequenceNumber>>24),
 		)
@@ -331,7 +340,8 @@ func (tx *Tx) CalcInputPreimageLegacy(inputNumber uint32, shf sighash.Flag) ([]b
 
 	buf = VarInt(uint64(len(txCopy.Outputs))).AppendTo(buf)
 	for _, out := range txCopy.Outputs {
-		buf = append(buf,
+		buf = append(
+			buf,
 			byte(out.Satoshis), byte(out.Satoshis>>8),
 			byte(out.Satoshis>>16), byte(out.Satoshis>>24),
 			byte(out.Satoshis>>32), byte(out.Satoshis>>40),
@@ -343,14 +353,16 @@ func (tx *Tx) CalcInputPreimageLegacy(inputNumber uint32, shf sighash.Flag) ([]b
 	}
 
 	// LockTime
-	buf = append(buf,
+	buf = append(
+		buf,
 		byte(tx.LockTime), byte(tx.LockTime>>8),
 		byte(tx.LockTime>>16), byte(tx.LockTime>>24),
 	)
 
 	// sighash flag
 	s := uint32(shf)
-	buf = append(buf,
+	buf = append(
+		buf,
 		byte(s), byte(s>>8),
 		byte(s>>16), byte(s>>24),
 	)

--- a/tx.go
+++ b/tx.go
@@ -571,7 +571,8 @@ func (tx *Tx) toBytesHelper(index int, lockingScript []byte, extended bool) []by
 // (provided h has sufficient capacity). This is the core serialization method
 // shared by both Bytes() and AppendBytes().
 func (tx *Tx) appendBytesHelper(h []byte, index int, lockingScript []byte, extended bool) []byte {
-	h = append(h,
+	h = append(
+		h,
 		byte(tx.Version),
 		byte(tx.Version>>8),
 		byte(tx.Version>>16),
@@ -602,7 +603,8 @@ func (tx *Tx) appendBytesHelper(h []byte, index int, lockingScript []byte, exten
 		h = out.appendTo(h)
 	}
 
-	return append(h,
+	return append(
+		h,
 		byte(tx.LockTime),
 		byte(tx.LockTime>>8),
 		byte(tx.LockTime>>16),

--- a/tx_change_test.go
+++ b/tx_change_test.go
@@ -11,7 +11,8 @@ import (
 
 func TestTx_ChangeToAddress(t *testing.T) {
 	t.Run("missing address and nil fees", func(t *testing.T) {
-		tx := newTxWithInput(t,
+		tx := newTxWithInput(
+			t,
 			"07912972e42095fe58daaf09161c5a5da57be47c2054dc2aaa52b30fefa1940b",
 			0,
 			"76a914af2590a45ae401651fdbdf59a76ad43d1862534088ac",
@@ -23,7 +24,8 @@ func TestTx_ChangeToAddress(t *testing.T) {
 	})
 
 	t.Run("nil fees, valid address", func(t *testing.T) {
-		tx := newTxWithInput(t,
+		tx := newTxWithInput(
+			t,
 			"07912972e42095fe58daaf09161c5a5da57be47c2054dc2aaa52b30fefa1940b",
 			0,
 			"76a914af2590a45ae401651fdbdf59a76ad43d1862534088ac",
@@ -35,7 +37,8 @@ func TestTx_ChangeToAddress(t *testing.T) {
 	})
 
 	t.Run("valid fees, valid address", func(t *testing.T) {
-		tx := newTxWithInput(t,
+		tx := newTxWithInput(
+			t,
 			"07912972e42095fe58daaf09161c5a5da57be47c2054dc2aaa52b30fefa1940b",
 			0,
 			"76a914af2590a45ae401651fdbdf59a76ad43d1862534088ac",
@@ -60,7 +63,8 @@ func TestTx_Change(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, expectedTx)
 
-		tx := newTxWithInput(t,
+		tx := newTxWithInput(
+			t,
 			"07912972e42095fe58daaf09161c5a5da57be47c2054dc2aaa52b30fefa1940b",
 			0,
 			"76a914af2590a45ae401651fdbdf59a76ad43d1862534088ac",
@@ -76,7 +80,8 @@ func TestTx_Change(t *testing.T) {
 	})
 
 	t.Run("change output is added correctly - fee removed", func(t *testing.T) {
-		tx := newTxWithInput(t,
+		tx := newTxWithInput(
+			t,
 			"07912972e42095fe58daaf09161c5a5da57be47c2054dc2aaa52b30fefa1940b",
 			0,
 			"76a914af2590a45ae401651fdbdf59a76ad43d1862534088ac",
@@ -92,14 +97,16 @@ func TestTx_Change(t *testing.T) {
 		assert.Equal(t, uint64(3999904), tx.Outputs[0].Satoshis)
 
 		// Correct script hex string
-		assert.Equal(t,
+		assert.Equal(
+			t,
 			"76a914af2590a45ae401651fdbdf59a76ad43d1862534088ac",
 			tx.OutputIdx(0).LockingScriptHexString(),
 		)
 	})
 
 	t.Run("determine fees are correct, correct change given", func(t *testing.T) {
-		tx := newTxWithInput(t,
+		tx := newTxWithInput(
+			t,
 			"b7b0650a7c3a1bd4716369783876348b59f5404784970192cec1996e86950576",
 			0,
 			"76a914af2590a45ae401651fdbdf59a76ad43d1862534088ac",
@@ -116,7 +123,8 @@ func TestTx_Change(t *testing.T) {
 
 		signAllInputs(t, tx, testWIF)
 
-		assert.Equal(t,
+		assert.Equal(
+			t,
 			"0100000001760595866e99c1ce920197844740f5598b34763878696371d41b3a7c0a65b0b7000000006a47304402206b5b0b6546dbaccab4cd9c5698eeab7883f79ddbd4cbc195d4458b48b7dba6460220297a4c4b145e644d23cebdd7593f407e8da9c5bb3c3219767207121d65658ae3412102c8803fdd437d902f08e3c2344cb33065c99d7c99982018ff9f7219c3dd352ff0ffffffff03f4010000000000001976a9147a1980655efbfec416b2b0c663a7b3ac0b6a25d288ac000000000000000011006a02686903686f770361726503796f7577010000000000001976a91484e50b300b009833b297dc671817c79b5459da1d88ac00000000",
 			tx.String(),
 		)
@@ -132,7 +140,8 @@ func TestTx_Change(t *testing.T) {
 	})
 
 	t.Run("spend entire utxo - basic - change address", func(t *testing.T) {
-		tx := newTxWithInput(t,
+		tx := newTxWithInput(
+			t,
 			"07912972e42095fe58daaf09161c5a5da57be47c2054dc2aaa52b30fefa1940b",
 			0,
 			"76a914af2590a45ae401651fdbdf59a76ad43d1862534088ac",
@@ -150,7 +159,8 @@ func TestTx_Change(t *testing.T) {
 	})
 
 	t.Run("spend entire utxo - multi payouts - expected fee", func(t *testing.T) {
-		tx := newTxWithInput(t,
+		tx := newTxWithInput(
+			t,
 			"07912972e42095fe58daaf09161c5a5da57be47c2054dc2aaa52b30fefa1940b",
 			0,
 			"76a914af2590a45ae401651fdbdf59a76ad43d1862534088ac",
@@ -175,7 +185,8 @@ func TestTx_Change(t *testing.T) {
 	})
 
 	t.Run("spend entire utxo - multi payouts - incorrect fee", func(t *testing.T) {
-		tx := newTxWithInput(t,
+		tx := newTxWithInput(
+			t,
 			"07912972e42095fe58daaf09161c5a5da57be47c2054dc2aaa52b30fefa1940b",
 			0,
 			"76a914af2590a45ae401651fdbdf59a76ad43d1862534088ac",
@@ -202,7 +213,8 @@ func TestTx_Change(t *testing.T) {
 	})
 
 	t.Run("multiple Inputs, spend all", func(t *testing.T) {
-		tx := newTxWithInput(t,
+		tx := newTxWithInput(
+			t,
 			"9e88ca8eec0845e9e864c024bc5e6711e670932c9c7d929f9fccdb2c440ae28e",
 			0,
 			"76a9147824dec00be2c45dad83c9b5e9f5d7ef05ba3cf988ac",
@@ -213,7 +225,8 @@ func TestTx_Change(t *testing.T) {
 			"4e25b077d4cbb955b5a215feb53f963cf04688ff1777b9bea097c7ddbdf7ea42",
 			0,
 			"76a9147824dec00be2c45dad83c9b5e9f5d7ef05ba3cf988ac",
-			5689)
+			5689,
+		)
 		require.NoError(t, err)
 
 		err = tx.ChangeToAddress("1BxGFoRPSFgYxoAStEncL6HuELqPkV3JVj", fq)
@@ -238,7 +251,8 @@ func TestTx_ChangeToOutput(t *testing.T) {
 	}{
 		"no change to add should return no change output": {
 			tx: func() *bt.Tx {
-				tx := newTxWithInput(t,
+				tx := newTxWithInput(
+					t,
 					"07912972e42095fe58daaf09161c5a5da57be47c2054dc2aaa52b30fefa1940b",
 					0,
 					"76a914af2590a45ae401651fdbdf59a76ad43d1862534088ac",
@@ -254,7 +268,8 @@ func TestTx_ChangeToOutput(t *testing.T) {
 			err:             nil,
 		}, "change to add should add change to output": {
 			tx: func() *bt.Tx {
-				tx := newTxWithInput(t,
+				tx := newTxWithInput(
+					t,
 					"07912972e42095fe58daaf09161c5a5da57be47c2054dc2aaa52b30fefa1940b",
 					0,
 					"76a914af2590a45ae401651fdbdf59a76ad43d1862534088ac",
@@ -270,7 +285,8 @@ func TestTx_ChangeToOutput(t *testing.T) {
 			err:             nil,
 		}, "change to add should add change to specified output": {
 			tx: func() *bt.Tx {
-				tx := newTxWithInput(t,
+				tx := newTxWithInput(
+					t,
 					"07912972e42095fe58daaf09161c5a5da57be47c2054dc2aaa52b30fefa1940b",
 					0,
 					"76a914af2590a45ae401651fdbdf59a76ad43d1862534088ac",
@@ -289,7 +305,8 @@ func TestTx_ChangeToOutput(t *testing.T) {
 			err:             nil,
 		}, "index out of range should return error": {
 			tx: func() *bt.Tx {
-				tx := newTxWithInput(t,
+				tx := newTxWithInput(
+					t,
 					"07912972e42095fe58daaf09161c5a5da57be47c2054dc2aaa52b30fefa1940b",
 					0,
 					"76a914af2590a45ae401651fdbdf59a76ad43d1862534088ac",

--- a/tx_input.go
+++ b/tx_input.go
@@ -178,7 +178,8 @@ func (tx *Tx) PreviousOutHash() []byte {
 
 	for _, in := range tx.Inputs {
 		buf = append(buf, in.previousTxIDHash[:]...)
-		buf = append(buf,
+		buf = append(
+			buf,
 			byte(in.PreviousTxOutIndex), byte(in.PreviousTxOutIndex>>8),
 			byte(in.PreviousTxOutIndex>>16), byte(in.PreviousTxOutIndex>>24),
 		)
@@ -192,7 +193,8 @@ func (tx *Tx) SequenceHash() []byte {
 	buf := make([]byte, 0, len(tx.Inputs)*4)
 
 	for _, in := range tx.Inputs {
-		buf = append(buf,
+		buf = append(
+			buf,
 			byte(in.SequenceNumber), byte(in.SequenceNumber>>8),
 			byte(in.SequenceNumber>>16), byte(in.SequenceNumber>>24),
 		)

--- a/tx_input_test.go
+++ b/tx_input_test.go
@@ -686,7 +686,8 @@ func TestTx_FillAllInputs(t *testing.T) {
 			"07912972e42095fe58daaf09161c5a5da57be47c2054dc2aaa52b30fefa1940b",
 			0,
 			"76a914af2590a45ae401651fdbdf59a76ad43d1862534088ac",
-			4000000)
+			4000000,
+		)
 		require.NoError(t, err)
 
 		err = tx.ChangeToAddress("mwV3YgnowbJJB3LcyCuqiKpdivvNNFiK7M", FQPoint5SatPerByte)

--- a/tx_output_test.go
+++ b/tx_output_test.go
@@ -26,7 +26,8 @@ func TestNewP2PKHOutputFromPubKeyHashStr(t *testing.T) {
 			uint64(5000),
 		)
 		require.NoError(t, err)
-		assert.Equal(t,
+		assert.Equal(
+			t,
 			"76a91488ac",
 			tx.Outputs[0].LockingScriptHexString(),
 		)
@@ -49,7 +50,8 @@ func TestNewP2PKHOutputFromPubKeyHashStr(t *testing.T) {
 			uint64(5000),
 		)
 		require.NoError(t, err)
-		assert.Equal(t,
+		assert.Equal(
+			t,
 			"76a9148fe80c75c9560e8b56ed64ea3c26e18d2c52211b88ac",
 			tx.Outputs[0].LockingScriptHexString(),
 		)
@@ -70,7 +72,8 @@ func TestNewHashPuzzleOutput(t *testing.T) {
 		err := tx.AddHashPuzzleOutput("", "", uint64(5000))
 
 		require.NoError(t, err)
-		assert.Equal(t,
+		assert.Equal(
+			t,
 			"a914b472a266d0bd89c13706a4132ccfb16f7c3b9fcb8876a90088ac",
 			tx.Outputs[0].LockingScriptHexString(),
 		)
@@ -85,7 +88,8 @@ func TestNewHashPuzzleOutput(t *testing.T) {
 		err = tx.AddHashPuzzleOutput("secret1", addr.PublicKeyHash, uint64(5000))
 
 		require.NoError(t, err)
-		assert.Equal(t,
+		assert.Equal(
+			t,
 			"a914d3f9e3d971764be5838307b175ee4e08ba427b908876a914c28f832c3d539933e0c719297340b34eee0f4c3488ac",
 			tx.Outputs[0].LockingScriptHexString(),
 		)
@@ -147,7 +151,8 @@ func TestTx_PayToAddress(t *testing.T) {
 			"07912972e42095fe58daaf09161c5a5da57be47c2054dc2aaa52b30fefa1940b",
 			0,
 			"76a914af2590a45ae401651fdbdf59a76ad43d1862534088ac",
-			4000000)
+			4000000,
+		)
 		require.NoError(t, err)
 
 		err = tx.PayToAddress("", 100)
@@ -161,7 +166,8 @@ func TestTx_PayToAddress(t *testing.T) {
 			"07912972e42095fe58daaf09161c5a5da57be47c2054dc2aaa52b30fefa1940b",
 			0,
 			"76a914af2590a45ae401651fdbdf59a76ad43d1862534088ac",
-			4000000)
+			4000000,
+		)
 		require.NoError(t, err)
 
 		err = tx.PayToAddress("1234567", 100)
@@ -175,7 +181,8 @@ func TestTx_PayToAddress(t *testing.T) {
 			"07912972e42095fe58daaf09161c5a5da57be47c2054dc2aaa52b30fefa1940b",
 			0,
 			"76a914af2590a45ae401651fdbdf59a76ad43d1862534088ac",
-			4000000)
+			4000000,
+		)
 		require.NoError(t, err)
 
 		err = tx.PayToAddress("1GHMW7ABrFma2NSwiVe9b9bZxkMB7tuPZi", 100)
@@ -213,7 +220,8 @@ func TestTx_PayTo(t *testing.T) {
 				"07912972e42095fe58daaf09161c5a5da57be47c2054dc2aaa52b30fefa1940b",
 				0,
 				"76a914af2590a45ae401651fdbdf59a76ad43d1862534088ac",
-				4000000)
+				4000000,
+			)
 			require.NoError(t, err)
 			err = tx.PayTo(test.script, 100)
 			if test.err == nil {

--- a/tx_test.go
+++ b/tx_test.go
@@ -255,7 +255,8 @@ func TestTxCreateTx(t *testing.T) {
 	tx := bt.NewTx()
 	assert.NotNil(t, tx)
 
-	mustFrom(t, tx,
+	mustFrom(
+		t, tx,
 		"3c8edde27cb9a9132c22038dac4391496be9db16fd21351565cc1006966fdad5",
 		0,
 		"76a914eb0bd5edba389198e73f8efabddfc61666969ff788ac",
@@ -276,7 +277,8 @@ func TestTxHasDataOutputs(t *testing.T) {
 		tx := bt.NewTx()
 		assert.NotNil(t, tx)
 
-		mustFrom(t, tx,
+		mustFrom(
+			t, tx,
 			"3c8edde27cb9a9132c22038dac4391496be9db16fd21351565cc1006966fdad5",
 			0,
 			"76a914eb0bd5edba389198e73f8efabddfc61666969ff788ac",
@@ -302,7 +304,8 @@ func TestTxHasDataOutputs(t *testing.T) {
 		tx := bt.NewTx()
 		assert.NotNil(t, tx)
 
-		mustFrom(t, tx,
+		mustFrom(
+			t, tx,
 			"3c8edde27cb9a9132c22038dac4391496be9db16fd21351565cc1006966fdad5",
 			0,
 			"76a914eb0bd5edba389198e73f8efabddfc61666969ff788ac",
@@ -1113,7 +1116,8 @@ func TestTxEstimateFeesPaidTotal(t *testing.T) {
 					"07912972e42095fe58daaf09161c5a5da57be47c2054dc2aaa52b30fefa1940b",
 					0,
 					"76a914af2590a45ae401651fdbdf59a76ad43d1862534088ac",
-					1000))
+					1000,
+				))
 				mustPayToAddress(t, tx, "mxAoAyZFXX6LZBWhoam3vjm6xt9NxPQ15f", 500)
 				return tx
 			}(),


### PR DESCRIPTION
## What Changed

* Updated `actions/checkout` from `v7.0.0` (commit `9c091bb`) to `v7.0.1` (commit `3d3c42e`) in `.github/actions/warm-cache/action.yml` (2 occurrences)
* Updated `github/codeql-action/init` from `v4.37.2` (commit `e064762`) to `v4.37.3` (commit `e4fba86`) in `.github/workflows/codeql-analysis.yml`
* Updated `github/codeql-action/autobuild` from `v4.37.2` (commit `e064762`) to `v4.37.3` (commit `e4fba86`) in `.github/workflows/codeql-analysis.yml`
* Updated `github/codeql-action/analyze` from `v4.37.2` (commit `e064762`) to `v4.37.3` (commit `e4fba86`) in `.github/workflows/codeql-analysis.yml`
* Updated `github/codeql-action/upload-sarif` from `v4.37.2` (commit `e064762`) to `v4.37.3` (commit `e4fba86`) in `.github/workflows/scorecard.yml`

## Why It Was Necessary

* Routine security and stability updates for GitHub Actions dependencies to incorporate latest patches and improvements
* Ensures CI/CD pipeline uses the most recent stable versions of checkout and CodeQL analysis actions
* Maintains alignment with GitHub's recommended action versions for security scanning and code analysis

## Testing Performed

* CI pipeline execution will validate the updated actions function correctly in the warm-cache workflow
* CodeQL analysis workflow will run with updated action versions to ensure security scanning continues without interruption
* Scorecard workflow will verify SARIF upload functionality remains intact with the updated CodeQL action

## Impact / Risk

* **Risk Level**: Low - patch version updates for well-maintained GitHub Actions
* **Breaking Changes**: None expected - these are minor version increments maintaining backward compatibility
* **CI/CD Impact**: No changes to workflow logic or behavior, only action version references updated

<!-- go-broadcast-metadata
group:
  id: bsv-blockchain-forks
  name: bsv-blockchain-forks
diff_info:
  staged_repo_available: true
  changed_files_count: 3
  files_with_original_content: 3
  files_without_original_content: 0
sync_metadata:
  source_repo: mrz1836/go-broadcast
  source_commit: 0f0717087ae0c640cd7648815a15736f770debaf
  target_repo: bsv-blockchain/go-bt
  sync_commit: 924bbbafd88e5c5b8686ebab03e146fdc2099dee
  sync_time: 2026-07-23T08:47:57-04:00
ai_generated:
  commit_message: true
  pr_body: true
directories:
  - src: .github/ISSUE_TEMPLATE
    dest: .github/ISSUE_TEMPLATE
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 3
    files_excluded: 0
    processing_time_ms: 304
  - src: .github/actions
    dest: .github/actions
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 1
    files_examined: 19
    files_excluded: 0
    processing_time_ms: 1127
  - src: .github/docs
    dest: .github/docs
    excluded: ["workflows-private.md"]
    files_synced: 0
    files_examined: 2
    files_excluded: 1
    processing_time_ms: 469
  - src: .github/env
    dest: .github/env
    excluded: ["20-guardian.env", "90-project.env", "99-local.env"]
    files_synced: 0
    files_examined: 9
    files_excluded: 2
    processing_time_ms: 548
  - src: .github/scripts
    dest: .github/scripts
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 1
    files_excluded: 0
    processing_time_ms: 256
  - src: .github/tech-conventions
    dest: .github/tech-conventions
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 14
    files_excluded: 0
    processing_time_ms: 1082
  - src: .github/workflows
    dest: .github/workflows
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 2
    files_examined: 20
    files_excluded: 0
    processing_time_ms: 1412
  - src: .vscode
    dest: .vscode
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 4
    files_excluded: 0
    processing_time_ms: 624
performance:
  total_files: 102
-->
